### PR TITLE
Fix Floating label overlap in TextArea

### DIFF
--- a/scss/_text_field.scss
+++ b/scss/_text_field.scss
@@ -1,8 +1,32 @@
 @import "node_modules/bootstrap/scss/forms";
 
 .form-floating {
-  > .form-control {
+
+  &:not(.form-floating--outlined) {
+    border-top-left-radius: 0.25rem !important;
+    border-top-right-radius: 0.25rem !important;
     background-color: $form-control-bg;
+
+    &:hover {
+      background-color: $form-control-hover-bg;
+    }
+
+    &:focus-within {
+      background-color: $form-control-active-bg;
+    }
+  }
+
+  > textarea.form-control {
+    margin: 1.625rem 0 0.2rem 0;
+    padding: 0 0.75rem;
+
+    &:focus, &:not(:placeholder-shown) {
+      padding: 0 0.75rem;
+    }
+  }
+
+  > .form-control {
+    background-color: transparent;
     border: 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -13,13 +37,7 @@
       border: 0;
     }
 
-    &:hover {
-      background-color: $form-control-hover-bg;
-    }
-
     &:focus, &.active {
-      background-color: $form-control-active-bg;
-
       ~ .m-line-ripple {
         background-size: 100% 2px, 100% 1px;
       }
@@ -33,9 +51,17 @@
   }
 
   &--outlined {
-    > .form-control {
-      background-color: transparent;
 
+    > textarea.form-control {
+      margin: 0.9125rem 0;
+      padding: 0 0.75rem;
+
+      &:focus, &:not(:placeholder-shown) {
+        padding: 0 0.75rem;
+      }
+    }
+
+    > .form-control {
       ~ .m-notch > .m-notch-between > label {
         color: $text-field-base-color;
         position: relative;
@@ -68,13 +94,7 @@
         }
       }
 
-      &:hover {
-        background-color: transparent;
-      }
-
       &:focus, &.active {
-        background-color: transparent;
-
         ~ .m-notch {
           > .m-notch-before,
           > .m-notch-between,

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -93,9 +93,9 @@ $text-field-primary-color: var(--text-field-primary-color, $primary);
 $form-floating-label-opacity: 1;
 $input-group-addon-bg: transparent;
 $input-group-addon-border-color: transparent;
-$form-control-bg: #fafafa;
-$form-control-hover-bg: #f5f5f5;
-$form-control-active-bg: #eee;
+$form-control-bg: #F5F5F5;
+$form-control-hover-bg: #eee;
+$form-control-active-bg: #E0E0E0;
 
 // Toast
 $toast-border-width: 0;

--- a/views/text-field.hbs
+++ b/views/text-field.hbs
@@ -176,7 +176,7 @@
                             <fieldset class="form-floating form-floating--outlined">
                                 <textarea class="form-control" id="address-outline"
                                           placeholder="address" style="height: 100px" required></textarea>
-                                <label for="address-outline">Comments</label>
+                                <label for="address-outline">Address</label>
                             </fieldset>
                             <div class="valid-feedback">
                                 Looks good!


### PR DESCRIPTION
 - Move :hover & :focus effects from .form-control to .form-floating
 - Remove top and bottom padding from TextArea and add margins instead, to make sure the floating label is out of the TextArea
 - Update :hover & :focus colors

Fixes #29 