### PR TITLE
Drop function setShapeOutline() from shape.js

### DIFF
--- a/js/src/shape.js
+++ b/js/src/shape.js
@@ -9,9 +9,6 @@ import BaseComponent from 'bootstrap/js/src/base-component'
 import {
   defineJQueryPlugin
 } from 'bootstrap/js/src/util/index'
-import {
-  getColor
-} from '../src/utility.js'
 
 /**
  * --------------------------------------------------------------------------
@@ -52,7 +49,6 @@ class Shape extends BaseComponent {
   initShape() {
     this.setShapeColor()
     this.setShapeSize()
-    this.setShapeOutline()
   }
 
   setShapeColor() {
@@ -137,36 +133,6 @@ class Shape extends BaseComponent {
       this._bottomRightAngle.style.right = `${-(bottomRightWidth / DIVISOR)}px`
       this._bottomRightAngle.style.width = `${bottomRightWidth}px`
       this._bottomRightAngle.style.height = `${bottomRightWidth}px`
-    }
-  }
-
-  setShapeOutline() {
-    let shapeOutline
-
-    const btnOutline = this._element.querySelector('[class*="btn-outline-"]')
-
-    if (btnOutline) {
-      shapeOutline = btnOutline.className.match(/btn-outline-[^\s]+/)
-      shapeOutline = shapeOutline[0].replace('btn-outline-', '')
-    }
-
-    if (shapeOutline) {
-      shapeOutline = getColor(shapeOutline)
-
-      const borderBottom = `1px solid ${shapeOutline}`
-
-      if (this._topLeftAngle) {
-        this._topLeftAngle.style.borderBottom = borderBottom
-      }
-      if (this._topRightAngle) {
-        this._topRightAngle.style.borderBottom = borderBottom
-      }
-      if (this._bottomLeftAngle) {
-        this._bottomLeftAngle.style.borderBottom = borderBottom
-      }
-      if (this._bottomRightAngle) {
-        this._bottomRightAngle.style.borderBottom = borderBottom
-      }
     }
   }
 }

--- a/site/content/3.0/utilities/shapes.md
+++ b/site/content/3.0/utilities/shapes.md
@@ -38,10 +38,10 @@ keywords: utilities, shapes
   <button type="button" class="btn btn-outline-purple">
     Button
   </button>
-  <div class="angle-top-left"></div>
-  <div class="angle-top-right"></div>
-  <div class="angle-bottom-left"></div>
-  <div class="angle-bottom-right"></div>
+  <div class="angle-top-left border border-bottom border-purple"></div>
+  <div class="angle-top-right border border-bottom border-purple"></div>
+  <div class="angle-bottom-left border border-bottom border-purple"></div>
+  <div class="angle-bottom-right border border-bottom border-purple"></div>
 </div>
 
 {{< /example >}}
@@ -59,7 +59,7 @@ keywords: utilities, shapes
       </p>
     </div>
     <div class="d-flex justify-content-between align-items-center flex-wrap p-2">
-      <button type="button" class="btn btn-text-purple">
+      <button type="button" class="btn btn-outline-purple border-0">
         Listen Now
       </button>
 
@@ -94,7 +94,7 @@ keywords: utilities, shapes
       </p>
     </div>
     <div class="d-flex justify-content-between align-items-center flex-wrap p-2">
-      <button type="button" class="btn btn-text-purple">
+      <button type="button" class="btn btn-outline-purple border-0">
         Listen Now
       </button>
 


### PR DESCRIPTION
Drop function setShapeOutline() from shape.js 
that was used to automatically set shape angle borders if ```.m-shape-container``` contained ```.btn-outline-*```