### PR TITLE
Update .form-floating-with-icon width on screens < 455px

### DIFF
--- a/site/assets/3.0/scss/site.scss
+++ b/site/assets/3.0/scss/site.scss
@@ -136,7 +136,8 @@ h5:not(.badge-example-headings h5) {
       max-width: 200px;
     }
 
-    .form-floating {
+    .form-floating,
+    .form-floating-with-icon {
       width: 200px;
     }
 


### PR DESCRIPTION
### Description

Update .form-floating-with-icon width on screens < 455px

#### Live previews

https://deploy-preview-77--materialstyle.netlify.app/materialstyle/3.0/forms/select-fields/

### Related issues

Closes #76 
