### PR TITLE
Add Dark Text and Select Fields

### DIFF
--- a/.bundlewatch.config.json
+++ b/.bundlewatch.config.json
@@ -18,43 +18,43 @@
     },
     {
       "path": "./dist/css/materialstyle-utilities.css",
-      "maxSize": "9.65 kB"
+      "maxSize": "11.05 kB"
     },
     {
       "path": "./dist/css/materialstyle-utilities.min.css",
-      "maxSize": "8.9 kB"
+      "maxSize": "10.25 kB"
     },
     {
       "path": "./dist/css/materialstyle.css",
-      "maxSize": "40.25 kB"
+      "maxSize": "41.1 kB"
     },
     {
       "path": "./dist/css/materialstyle.min.css",
-      "maxSize": "37.25 kB"
+      "maxSize": "38 kB"
     },
     {
       "path": "./dist/js/materialstyle.bundle.js",
-      "maxSize": "48.8 kB"
+      "maxSize": "48.9 kB"
     },
     {
       "path": "./dist/js/materialstyle.bundle.min.js",
-      "maxSize": "26.55 kB"
+      "maxSize": "26.7 kB"
     },
     {
       "path": "./dist/js/materialstyle.esm.js",
-      "maxSize": "33.6 kB"
+      "maxSize": "33.65 kB"
     },
     {
       "path": "./dist/js/materialstyle.esm.min.js",
-      "maxSize": "22.35 kB"
+      "maxSize": "22.5 kB"
     },
     {
       "path": "./dist/js/materialstyle.js",
-      "maxSize": "34.41 kB"
+      "maxSize": "34.5 kB"
     },
     {
       "path": "./dist/js/materialstyle.min.js",
-      "maxSize": "19.5 kB"
+      "maxSize": "19.7 kB"
     }
   ],
   "ci": {

--- a/js/src/select-field.js
+++ b/js/src/select-field.js
@@ -87,8 +87,8 @@ class SelectField extends BaseComponent {
     this._isSearchable = Boolean(this._formFloating.className.includes(CLASS_NAME_SEARCHABLE))
     this._multiSelectEnabled = Boolean(this._formFloating.className.includes(CLASS_NAME_MULTI_SELECT))
 
-    this._formFloating.style.setProperty('--form-field-base-color', getBaseColor(this._formFloating))
-    this._formFloating.style.setProperty('--form-field-primary-color', getPrimaryColor(this._formFloating))
+    this._formFloating.style.setProperty('--bs-form-field-border-color', getBaseColor(this._formFloating))
+    this._formFloating.style.setProperty('--bs-form-field-active-border-color', getPrimaryColor(this._formFloating))
 
     this._label = this._formFloating.querySelector('label')
     this._inputGroup = this._formFloating.closest('.input-group')

--- a/js/src/select-field.js
+++ b/js/src/select-field.js
@@ -36,6 +36,7 @@ const EVENT_SHOWN = 'shown.bs.dropdown'
 
 const CLASS_NAME_FLOATING = 'form-floating'
 const CLASS_NAME_FLOATING_OUTLINED = 'form-floating-outlined'
+const CLASS_NAME_FLOATING_DARK = 'form-floating-dark'
 
 const CLASS_NAME_SEARCHABLE = 'searchable'
 const CLASS_NAME_MULTI_SELECT = 'multi-select'
@@ -152,7 +153,7 @@ class SelectField extends BaseComponent {
     if (dropdownMenu === undefined) {
       dropdownMenu = document.createElement('div')
       dropdownMenu.role = 'listbox'
-      dropdownMenu.className = 'dropdown-menu'
+      dropdownMenu.className = 'dropdown-menu mb-2'
       dropdownMenu.setAttribute('aria-label', this._label ? this._label.innerHTML : 'Select Field')
       dropdownMenu.id = `listbox${Date.now().toString(TO_STRING_BASE)}${Math.random().toString(TO_STRING_BASE).slice(SUBSTR_INDEX)}${Date.now().toString(TO_STRING_BASE)}listbox`
     }
@@ -182,7 +183,7 @@ class SelectField extends BaseComponent {
     if (this._multiSelectEnabled) {
       const closeButton = document.createElement('button')
       closeButton.type = 'button'
-      closeButton.className = 'btn-close dropdown-item w-100'
+      closeButton.className = `btn-close ${(this._formFloating.className.includes(CLASS_NAME_FLOATING_DARK) ? 'btn-close-white' : '')} dropdown-item w-100`
       closeButton.setAttribute('aria-label', 'Close listbox')
 
       this._closeButton = closeButton
@@ -269,7 +270,7 @@ class SelectField extends BaseComponent {
     if (this._multiSelectEnabled) {
       this._selectedItem.innerHTML = this._options.map(option => {
         if (option.selected) {
-          return `<span class="badge d-inline-flex align-items-center p-0">${option.text}<button type="button" class="btn-close ms-1" aria-label="Deselect ${option.text}" data-value="${option.value}"></button></span>`
+          return `<span class="badge d-inline-flex align-items-center p-0">${option.text}<button type="button" class="btn-close ${(this._formFloating.className.includes(CLASS_NAME_FLOATING_DARK) ? 'btn-close-white' : '')}" aria-label="Deselect ${option.text}" data-value="${option.value}"></button></span>`
         }
 
         return ''

--- a/js/src/text-field.js
+++ b/js/src/text-field.js
@@ -62,8 +62,8 @@ class TextField extends BaseComponent {
   }
 
   initTextFields() {
-    this._formFloating.style.setProperty('--form-field-base-color', getBaseColor(this._formFloating))
-    this._formFloating.style.setProperty('--form-field-primary-color', getPrimaryColor(this._formFloating))
+    this._formFloating.style.setProperty('--bs-form-field-border-color', getBaseColor(this._formFloating))
+    this._formFloating.style.setProperty('--bs-form-field-active-border-color', getPrimaryColor(this._formFloating))
 
     this._label = this._formFloating.querySelector('label')
     this._inputGroup = this._formFloating.closest('.input-group')

--- a/js/src/util/color.js
+++ b/js/src/util/color.js
@@ -22,6 +22,10 @@ const getBaseColor = element => {
   let base = element.className.match(/base-\S+/)
   let baseColor = '#757575'
 
+  if (element.classList.contains('form-floating-dark')) {
+    baseColor = '#fff'
+  }
+
   if (base) {
     base = base[0].replace('base-', '')
     baseColor = getColor(base)
@@ -33,6 +37,10 @@ const getBaseColor = element => {
 const getPrimaryColor = element => {
   let primary = element.className.match(/primary-\S+/)
   let primaryColor = '#0d6efd'
+
+  if (element.classList.contains('form-floating-dark')) {
+    primaryColor = '#0dcaf0'
+  }
 
   if (primary) {
     primary = primary[0].replace('primary-', '')

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -823,12 +823,19 @@ $btn-active-bg-tint-amount:       20% !default;
 
 
 // Forms
+$form-field-color:               $dark !default;
+$form-field-bg:                  #f5f5f5 !default;
+$form-field-hover-bg:            #eee !default;
+$form-field-active-bg:           #e0e0e0 !default;
+$form-field-border-color:        #757575 !default;
+$form-field-active-border-color: $primary !default;
 
-$form-field-base-color:    var(--form-field-base-color, #757575) !default;
-$form-field-primary-color: var(--form-field-primary-color, $primary) !default;
-$form-control-bg:          #f5f5f5 !default;
-$form-control-hover-bg:    #eee !default;
-$form-control-active-bg:   #e0e0e0 !default;
+$form-field-dark-color:               $light !default;
+$form-field-dark-bg:                  $gray-900 !default;
+$form-field-dark-hover-bg:            $gray-800 !default;
+$form-field-dark-active-bg:           $gray-700 !default;
+$form-field-dark-border-color:        $light !default;
+$form-field-dark-active-border-color: $primary !default;
 
 // scss-docs-start form-text-variables
 $form-text-margin-top:                  .25rem !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -823,19 +823,21 @@ $btn-active-bg-tint-amount:       20% !default;
 
 
 // Forms
-$form-field-color:               $dark !default;
-$form-field-bg:                  #f5f5f5 !default;
-$form-field-hover-bg:            #eee !default;
-$form-field-active-bg:           #e0e0e0 !default;
-$form-field-border-color:        #757575 !default;
-$form-field-active-border-color: $primary !default;
+$form-field-color:                      $dark !default;
+$form-field-bg:                         $gray-100 !default;
+$form-field-hover-bg:                   $gray-200 !default;
+$form-field-active-bg:                  $gray-300 !default;
+$form-field-border-color:               $dark !default;
+$form-field-active-border-color:        $primary !default;
+$form-select-checkmark:                 url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$gray-800}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") !default;
 
-$form-field-dark-color:               $light !default;
-$form-field-dark-bg:                  $gray-900 !default;
-$form-field-dark-hover-bg:            $gray-800 !default;
-$form-field-dark-active-bg:           $gray-700 !default;
-$form-field-dark-border-color:        $light !default;
-$form-field-dark-active-border-color: $primary !default;
+$form-field-dark-color:                 $light !default;
+$form-field-dark-bg:                    $gray-900 !default;
+$form-field-dark-hover-bg:              $gray-800 !default;
+$form-field-dark-active-bg:             $gray-700 !default;
+$form-field-dark-border-color:          $light !default;
+$form-field-dark-active-border-color:   $primary !default;
+$form-select-checkmark-dark:            url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$gray-100}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/></svg>") !default;
 
 // scss-docs-start form-text-variables
 $form-text-margin-top:                  .25rem !default;
@@ -988,6 +990,8 @@ $form-select-bg-position:           right $form-select-padding-x center !default
 $form-select-bg-size:               16px 12px !default; // In pixels because image dimensions
 $form-select-indicator-color:       $gray-800 !default;
 $form-select-indicator:             url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
+$form-select-indicator-dark-color:  $gray-100 !default;
+$form-select-indicator-dark:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-dark-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>") !default;
 
 $form-select-feedback-icon-padding-end: $form-select-padding-x * 2.5 + $form-select-indicator-padding !default;
 $form-select-feedback-icon-position:    center right $form-select-indicator-padding !default;

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -1,13 +1,27 @@
 // stylelint-disable selector-max-class, selector-max-compound-selectors, selector-no-qualifying-type, function-disallowed-list
 .form-floating {
+  --#{$prefix}form-field-color: #{$form-field-color};
+  --#{$prefix}form-field-bg: #{$form-field-bg};
+  --#{$prefix}form-field-hover-bg: #{$form-field-hover-bg};
+  --#{$prefix}form-field-active-bg: #{$form-field-active-bg};
+  --#{$prefix}form-field-border-color: #{$form-field-border-color};
+  --#{$prefix}form-field-active-border-color: #{$form-field-active-border-color};
+
   position: relative;
   width: 100%;
 
-  > .form-control,
-  > .form-control-plaintext,
-  > .dropdown > .dropdown-toggle {
-    height: $form-floating-height;
-    line-height: $form-floating-line-height;
+  &:not(.form-floating-outlined) {
+    background-color: var(--#{$prefix}form-field-bg);
+    @include border-top-start-radius($border-radius);
+    @include border-top-end-radius($border-radius);
+
+    &:hover {
+      background-color: var(--#{$prefix}form-field-hover-bg);
+    }
+
+    &:focus-within {
+      background-color: var(--#{$prefix}form-field-active-bg);
+    }
   }
 
   > label {
@@ -15,10 +29,10 @@
     top: 0;
     left: 0;
     width: 100%;
-    height: 100%; // allow textareas
+    height: 100%;
     padding: $form-floating-padding-y $form-floating-padding-x;
     overflow: hidden;
-    color: $form-field-base-color;
+    color: var(--#{$prefix}form-field-border-color);
     text-overflow: ellipsis;
     white-space: nowrap;
     pointer-events: none;
@@ -29,7 +43,10 @@
 
   > .form-control,
   > .form-control-plaintext {
+    height: $form-floating-height;
     padding: $form-floating-padding-y var(--append-width, $form-floating-padding-x) $form-floating-padding-y var(--prepend-width, $form-floating-padding-x);
+    line-height: $form-floating-line-height;
+    color: var(--#{$prefix}form-field-color);
     background-color: transparent;
     border: 0;
     @include border-bottom-end-radius(0);
@@ -55,7 +72,7 @@
 
   > textarea.form-control {
     padding: 0 var(--prepend-width, $input-padding-x);
-    margin: 1.625rem 0 .2rem 0; // stylelint-disable shorthand-property-no-redundant-values
+    margin: 1.625rem 0 .2rem 0; // stylelint-disable-line shorthand-property-no-redundant-values
 
     &:focus,
     &:not(:placeholder-shown) {
@@ -81,11 +98,13 @@
     > .dropdown-toggle {
       display: block;
       width: 100%;
-      height: auto;
+      height: $form-floating-height;
       min-height: 60px;
       max-height: 300px;
       padding: $form-select-padding-y calc(var(--append-width, 0px) + $form-select-indicator-padding) $form-select-padding-y var(--prepend-width, $form-select-padding-x);
       overflow: auto;
+      line-height: $form-floating-line-height;
+      color: var(--#{$prefix}form-field-color);
       background-image: escape-svg($form-select-indicator);
       background-repeat: no-repeat;
       background-position: right var(--append-width, $form-select-padding-x) center;
@@ -97,6 +116,22 @@
       }
     }
 
+    .dropdown-menu {
+      --#{$prefix}dropdown-link-color: #{$dark};
+      --#{$prefix}dropdown-link-hover-color: #{$dark};
+      --#{$prefix}dropdown-link-hover-bg: #{$gray-100};
+      --#{$prefix}dropdown-link-active-color: #{$dark};
+      --#{$prefix}dropdown-link-active-bg: #{$gray-200};
+      --#{$prefix}dropdown-link-active-hover-bg: #{$gray-300};
+
+      width: 100%;
+      max-height: 40vh;
+      padding: 0;
+      overflow-y: auto;
+      user-select: none;
+      border: hidden;
+    }
+
     .dropdown-item {
       min-height: 40px;
       > * {
@@ -106,21 +141,19 @@
       &:hover,
       &:focus,
       &:focus-visible {
-        color: $dark;
-        background-color: $gray-100;
         outline: 0;
       }
 
       &.active,
       &[aria-selected="true"],
       &:active {
-        color: $dark;
-        background-color: $gray-200;
+        color: var(--#{$prefix}dropdown-link-active-color);
+        background-color: var(--#{$prefix}dropdown-link-active-bg);
 
         &:hover,
         &:focus,
         &:focus-visible {
-          background-color: $gray-300;
+          background-color: var(--#{$prefix}dropdown-link-active-hover-bg);
           outline: 0;
         }
       }
@@ -134,10 +167,11 @@
     }
   }
 
+  // Label & Ripple color
   > .form-control:focus,
   > .dropdown:focus-within {
     ~ label {
-      color: $form-field-primary-color;
+      color: var(--#{$prefix}form-field-active-border-color);
     }
 
     ~ .m-line-ripple {
@@ -154,6 +188,7 @@
       transform: $form-floating-label-transform;
     }
   }
+
   // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
   > .form-control:-webkit-autofill {
     ~ label {
@@ -168,6 +203,7 @@
     }
   }
 
+  // Search input
   .search-input {
     display: block;
     width: 100%;
@@ -184,15 +220,7 @@
     }
   }
 
-  .dropdown-menu {
-    width: 100%;
-    max-height: 40vh;
-    padding: 0;
-    overflow-y: auto;
-    user-select: none;
-    border: hidden;
-  }
-
+  // Multi select
   &.multi-select {
     .dropdown-toggle {
       display: flex;
@@ -229,7 +257,19 @@
     }
   }
 
+  // Form floating outlined
   &.form-floating-outlined {
+    .m-notch > .m-notch-between > label {
+      position: relative;
+      top: 0;
+      left: 0;
+      height: 100%;
+      padding: 1rem 0;
+      color: var(--#{$prefix}form-field-border-color);
+      pointer-events: none;
+      @include transition(opacity .1s ease-in-out, transform .1s ease-in-out);
+      transform-origin: 0 0;
+    }
 
     > textarea.form-control {
       padding: 0 .75rem;
@@ -241,21 +281,7 @@
       }
     }
 
-    > .form-control,
-    > .dropdown {
-      ~ .m-notch > .m-notch-between > label {
-        position: relative;
-        top: 0;
-        left: 0;
-        height: 100%;
-        padding: 1rem 0;
-        color: $form-field-base-color;
-        pointer-events: none;
-        @include transition(opacity .1s ease-in-out, transform .1s ease-in-out);
-        transform-origin: 0 0;
-      }
-    }
-
+    // Padding
     > .form-control {
       &:focus,
       &:not(:placeholder-shown) {
@@ -269,8 +295,27 @@
       }
     }
 
+    // Focused
+    > .form-control:focus,
+    > .dropdown:focus-within {
+      ~ .m-notch {
+        > .m-notch-before,
+        > .m-notch-between,
+        > .m-notch-after {
+          border-color: var(--#{$prefix}form-field-active-border-color);
+          border-width: 2px;
+        }
+
+        > .m-notch-between > label {
+          color: var(--#{$prefix}form-field-active-border-color);
+        }
+      }
+    }
+
+    // Form field is either focused or it has content
     > .form-control:focus,
     > .form-control:not(:placeholder-shown),
+    > .dropdown:focus-within,
     > .dropdown.float {
       ~ .m-notch > .m-notch-between {
         border-top: 0;
@@ -282,48 +327,44 @@
         }
       }
     }
-
-    > .form-control:focus,
-    > .dropdown:focus-within {
-      ~ .m-notch > .m-notch-between > label {
-        color: $form-field-primary-color;
-      }
-
-      ~ .m-notch {
-        > .m-notch-before,
-        > .m-notch-between,
-        > .m-notch-after {
-          border-color: $form-field-primary-color;
-          border-width: 2px;
-        }
-      }
-    }
   }
 
-  &:not(.form-floating-outlined) {
-    background-color: $form-control-bg;
-    @include border-top-start-radius($border-radius);
-    @include border-top-end-radius($border-radius);
+  // Form floating dark
+  &.form-floating-dark {
+    --#{$prefix}form-field-color: #{$form-field-dark-color};
+    --#{$prefix}form-field-bg: #{$form-field-dark-bg};
+    --#{$prefix}form-field-hover-bg: #{$form-field-dark-hover-bg};
+    --#{$prefix}form-field-active-bg: #{$form-field-dark-active-bg};
+    --#{$prefix}form-field-border-color: #{$form-field-dark-border-color};
+    --#{$prefix}form-field-active-border-color: #{$form-field-dark-active-border-color};
 
-    &:hover {
-      background-color: $form-control-hover-bg;
-    }
-
-    &:focus-within {
-      background-color: $form-control-active-bg;
+    .dropdown-menu {
+      --#{$prefix}dropdown-color: #{$form-field-dark-color};
+      --#{$prefix}dropdown-bg: #{$form-field-dark-bg};
+      --#{$prefix}dropdown-border-color: #{$dropdown-dark-border-color};
+      --#{$prefix}dropdown-box-shadow: #{$dropdown-dark-box-shadow};
+      --#{$prefix}dropdown-link-color: #{$dropdown-dark-link-color};
+      --#{$prefix}dropdown-link-hover-color: #{$dropdown-dark-link-hover-color};
+      --#{$prefix}dropdown-divider-bg: #{$dropdown-dark-divider-bg};
+      --#{$prefix}dropdown-link-hover-bg: #{$dropdown-dark-link-hover-bg};
+      --#{$prefix}dropdown-link-active-color: #{$dropdown-dark-link-active-color};
+      --#{$prefix}dropdown-link-active-bg: #{$gray-700};
+      --#{$prefix}dropdown-link-disabled-color: #{$dropdown-dark-link-disabled-color};
+      --#{$prefix}dropdown-header-color: #{$dropdown-dark-header-color};
+      --#{$prefix}dropdown-link-active-hover-bg: #{$gray-600};
     }
   }
 }
 
-// Line ripple and Notch
+// Ripple and Notch
 .m-line-ripple {
   position: relative;
   width: 100%;
   height: 2px;
   // stylelint-disable value-list-comma-newline-after, value-list-comma-space-after
   background:
-    linear-gradient($form-field-primary-color, $form-field-primary-color) bottom/0 2px no-repeat border-box,
-    linear-gradient($form-field-base-color, $form-field-base-color) bottom/100% 1px no-repeat border-box transparent;
+    linear-gradient(var(--#{$prefix}form-field-active-border-color), var(--#{$prefix}form-field-active-border-color)) bottom/0 2px no-repeat border-box,
+    linear-gradient(var(--#{$prefix}form-field-border-color), var(--#{$prefix}form-field-border-color)) bottom/100% 1px no-repeat border-box transparent;
   // stylelint-enable value-list-comma-newline-after, value-list-comma-space-after
   @include transition(.3s cubic-bezier(.4, 0, .2, 1));
 }
@@ -346,7 +387,7 @@
   .m-notch-between,
   .m-notch-after {
     pointer-events: none;
-    border: 1px solid $form-field-base-color;
+    border: 1px solid var(--#{$prefix}form-field-border-color);
     @include border-radius(.25rem);
   }
 
@@ -376,6 +417,7 @@
   }
 }
 
+// Form floating with icon
 .form-floating-with-icon {
   position: relative;
   width: 100%;

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -6,6 +6,8 @@
   --#{$prefix}form-field-active-bg: #{$form-field-active-bg};
   --#{$prefix}form-field-border-color: #{$form-field-border-color};
   --#{$prefix}form-field-active-border-color: #{$form-field-active-border-color};
+  --#{$prefix}form-select-indicator: #{escape-svg($form-select-indicator)};
+  --#{$prefix}form-select-checkmark: #{escape-svg($form-select-checkmark)};
 
   position: relative;
   width: 100%;
@@ -36,7 +38,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     pointer-events: none;
-    border: $input-border-width solid transparent; // Required for aligning label's text with the input as it affects inner box model
     transform-origin: 0 0;
     @include transition($form-floating-transition);
   }
@@ -98,14 +99,14 @@
     > .dropdown-toggle {
       display: block;
       width: 100%;
-      height: $form-floating-height;
+      height: auto;
       min-height: 60px;
       max-height: 300px;
       padding: $form-select-padding-y calc(var(--append-width, 0px) + $form-select-indicator-padding) $form-select-padding-y var(--prepend-width, $form-select-padding-x);
       overflow: auto;
       line-height: $form-floating-line-height;
       color: var(--#{$prefix}form-field-color);
-      background-image: escape-svg($form-select-indicator);
+      background-image: var(--#{$prefix}form-select-indicator);
       background-repeat: no-repeat;
       background-position: right var(--append-width, $form-select-padding-x) center;
       background-size: $form-select-bg-size;
@@ -117,12 +118,12 @@
     }
 
     .dropdown-menu {
-      --#{$prefix}dropdown-link-color: #{$dark};
-      --#{$prefix}dropdown-link-hover-color: #{$dark};
-      --#{$prefix}dropdown-link-hover-bg: #{$gray-100};
-      --#{$prefix}dropdown-link-active-color: #{$dark};
-      --#{$prefix}dropdown-link-active-bg: #{$gray-200};
-      --#{$prefix}dropdown-link-active-hover-bg: #{$gray-300};
+      --#{$prefix}dropdown-link-color: var(--#{$prefix}form-field-color);
+      --#{$prefix}dropdown-link-hover-color: var(--#{$prefix}form-field-color);
+      --#{$prefix}dropdown-link-hover-bg: var(--#{$prefix}form-field-hover-bg);
+      --#{$prefix}dropdown-link-active-color: var(--#{$prefix}form-field-color);
+      --#{$prefix}dropdown-link-active-bg: var(--#{$prefix}form-field-active-bg);
+      --#{$prefix}dropdown-link-active-hover-bg: #{$gray-400};
 
       width: 100%;
       max-height: 40vh;
@@ -229,10 +230,9 @@
       white-space: normal;
 
       .badge {
-        --bs-badge-color: inherit;
+        --bs-badge-color: var(--#{$prefix}form-field-color);
 
         .btn-close {
-          --bs-btn-close-color: inherit;
           cursor: pointer;
         }
       }
@@ -242,6 +242,11 @@
       box-sizing: border-box;
       @include border-radius(0);
       box-shadow: none;
+
+      &.btn-close-white {
+        --#{$prefix}btn-close-bg: #{ escape-svg(url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$white}'><path d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/></svg>")) };
+        filter: none;
+      }
     }
 
     .checkmark {
@@ -253,7 +258,7 @@
 
     .dropdown-item[aria-selected="true"] > .checkmark {
       visibility: visible;
-      background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23000' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10l3 3l6-6'/%3e%3c/svg%3e");
+      background-image: var(--#{$prefix}form-select-checkmark);
     }
   }
 
@@ -337,6 +342,8 @@
     --#{$prefix}form-field-active-bg: #{$form-field-dark-active-bg};
     --#{$prefix}form-field-border-color: #{$form-field-dark-border-color};
     --#{$prefix}form-field-active-border-color: #{$form-field-dark-active-border-color};
+    --#{$prefix}form-select-indicator: #{escape-svg($form-select-indicator-dark)};
+    --#{$prefix}form-select-checkmark: #{escape-svg($form-select-checkmark-dark)};
 
     .dropdown-menu {
       --#{$prefix}dropdown-color: #{$form-field-dark-color};

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -93,9 +93,6 @@
   }
 
   > .dropdown {
-    border-right: 2px solid transparent;
-    border-left: 2px solid transparent;
-
     > .dropdown-toggle {
       display: block;
       width: 100%;

--- a/site/content/3.0/forms/select-fields.md
+++ b/site/content/3.0/forms/select-fields.md
@@ -23,7 +23,7 @@ Note that the ```<select>``` must come first so we can utilize a sibling selecto
 {{< /callout >}}
 
 ## Filled
-{{< example codeId="code1" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code1" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating">
   <select class="form-select">
@@ -51,7 +51,7 @@ Note that the ```<select>``` must come first so we can utilize a sibling selecto
 
 ## Outlined
 
-{{< example codeId="code2" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code2" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating form-floating-outlined">
   <select class="form-select">
@@ -80,7 +80,7 @@ Note that the ```<select>``` must come first so we can utilize a sibling selecto
 ## Color options
 Make use of ```.base-[color]``` & ```.primary-[color]``` classes to personalize it according to your brand's style.
 
-{{< example codeId="code3" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code3" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating base-purple primary-pink">
   <select class="form-select">
@@ -109,7 +109,7 @@ Make use of ```.base-[color]``` & ```.primary-[color]``` classes to personalize 
 ## Searchable
 Add class ```searchable``` on ```.form-floating``` to add a search box to the menu.
 
-{{< example codeId="code4" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code4" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating searchable">
   <select class="form-select">
@@ -136,7 +136,7 @@ Add class ```searchable``` on ```.form-floating``` to add a search box to the me
 {{< /example >}}
 
 ## With Icon
-{{< example codeId="code5" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code5" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating-with-icon">
   <div class="form-floating">
@@ -205,7 +205,7 @@ Add class ```searchable``` on ```.form-floating``` to add a search box to the me
 {{< /example >}}
 
 ## With Spinner
-{{< example codeId="code6" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code6" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating-with-icon">
   <div class="form-floating">
@@ -284,7 +284,7 @@ Add class ```searchable``` on ```.form-floating``` to add a search box to the me
 ## Multi Select
 Add class ```multi-select``` on ```.form-floating``` to enable multi select.
 
-{{< example codeId="code7" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code7" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating multi-select">
   <select class="form-select" name="cars[]" multiple>
@@ -293,7 +293,7 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
     <option value="3">Option 3</option>
     <option value="4">Option 4</option>
   </select>
-  <label>Select</label>
+  <label>Select Multiple</label>
 </div>
 ##split##
 <div class="form-floating form-floating-outlined multi-select">
@@ -303,13 +303,13 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
     <option value="3">Option 3</option>
     <option value="4">Option 4</option>
   </select>
-  <label>Select</label>
+  <label>Select Multiple</label>
 </div>
 
 {{< /example >}}
 
 ## Multi Select Searchable
-{{< example codeId="code8" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code8" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating multi-select searchable">
   <select class="form-select" name="cars[]" multiple>
@@ -334,7 +334,7 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
 {{< /example >}}
 
 ## Multi Select With Icon
-{{< example codeId="code9" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code9" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating-with-icon">
   <div class="form-floating multi-select">
@@ -344,7 +344,7 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
       <option value="3">Option 3</option>
       <option value="4">Option 4</option>
     </select>
-    <label>Select</label>
+    <label>Select Multiple</label>
   </div>
   <div class="prepend">
     <i class="bi bi-star-fill"></i>
@@ -359,7 +359,7 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
       <option value="3">Option 3</option>
       <option value="4">Option 4</option>
     </select>
-    <label>Select</label>
+    <label>Select Multiple</label>
   </div>
   <div class="append">
     <i class="bi bi-star-fill"></i>
@@ -369,7 +369,7 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
 {{< /example >}}
 
 ## Multi Select With Spinner
-{{< example codeId="code10" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code10" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating-with-icon">
   <div class="form-floating multi-select">
@@ -379,7 +379,7 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
       <option value="3">Option 3</option>
       <option value="4">Option 4</option>
     </select>
-    <label>Select</label>
+    <label>Select Multiple</label>
   </div>
   <div class="prepend">
     <div class="spinner-material text-blue">
@@ -398,11 +398,90 @@ Add class ```multi-select``` on ```.form-floating``` to enable multi select.
       <option value="3">Option 3</option>
       <option value="4">Option 4</option>
     </select>
-    <label>Select</label>
+    <label>Select Multiple</label>
   </div>
   <div class="append">
     <div class="spinner-grow text-primary"></div>
   </div>
+</div>
+
+{{< /example >}}
+
+## Dark Select
+{{< example codeId="code11" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3 bg-dark rounded-top">}}
+
+<div class="form-floating form-floating-dark">
+  <select class="form-select">
+    <option value="" label="blank option"></option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+  </select>
+  <label>Select One</label>
+</div>
+##split##
+<div class="form-floating form-floating-outlined form-floating-dark">
+  <select class="form-select">
+    <option value="" label="blank option"></option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+  </select>
+  <label>Select One</label>
+</div>
+
+{{< /example >}}
+
+## Dark Multi Select
+{{< example codeId="code12" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3 bg-dark rounded-top">}}
+
+<div class="form-floating form-floating-dark multi-select">
+  <select class="form-select" multiple>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+  </select>
+  <label>Select Multiple</label>
+</div>
+##split##
+<div class="form-floating form-floating-outlined form-floating-dark multi-select">
+  <select class="form-select" multiple>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+  </select>
+  <label>Select Multiple</label>
+</div>
+
+{{< /example >}}
+
+## Dark Select with custom color
+{{< example codeId="code13" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3 bg-dark rounded-top">}}
+
+<div class="form-floating form-floating-dark base-cyan primary-yellow">
+  <select class="form-select">
+    <option value="" label="blank option"></option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+  </select>
+  <label>Select One</label>
+</div>
+##split##
+<div class="form-floating form-floating-outlined form-floating-dark base-cyan primary-yellow">
+  <select class="form-select">
+    <option value="" label="blank option"></option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <option value="4">Option 4</option>
+  </select>
+  <label>Select One</label>
 </div>
 
 {{< /example >}}

--- a/site/content/3.0/forms/text-fields.md
+++ b/site/content/3.0/forms/text-fields.md
@@ -26,7 +26,7 @@ Also note that the ```<input>``` must come first so we can utilize a sibling sel
 {{< /callout >}}
 
 ## Filled
-{{< example codeId="code1" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code1" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating">
   <input type="text" class="form-control" id="firstname"
@@ -44,7 +44,7 @@ Also note that the ```<input>``` must come first so we can utilize a sibling sel
 
 ## Outlined
 
-{{< example codeId="code2" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code2" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating form-floating-outlined">
   <input type="text" class="form-control" id="firstname-outline"
@@ -63,7 +63,7 @@ Also note that the ```<input>``` must come first so we can utilize a sibling sel
 ## Color options
 Make use of ```.base-[color]``` & ```.primary-[color]``` classes to personalize it according to your brand's style.
 
-{{< example codeId="code3" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code3" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating base-purple primary-pink">
   <input type="text" class="form-control" id="lastname"
@@ -81,7 +81,7 @@ Make use of ```.base-[color]``` & ```.primary-[color]``` classes to personalize 
 
 ## With Icon
 
-{{< example codeId="code4" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code4" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating-with-icon">
   <div class="form-floating">
@@ -131,7 +131,7 @@ Make use of ```.base-[color]``` & ```.primary-[color]``` classes to personalize 
 
 ## With Spinner
 
-{{< example codeId="code5" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code5" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating-with-icon">
   <div class="form-floating">
@@ -190,7 +190,7 @@ Make use of ```.base-[color]``` & ```.primary-[color]``` classes to personalize 
 ## Text Area
 To set a custom height on your ```<textarea>```, do not use the rows attribute. Instead, set an explicit height (either inline or via custom CSS).
 
-{{< example codeId="code6" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code6" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating">
   <textarea class="form-control" placeholder="address"
@@ -211,7 +211,7 @@ If you want to have ```<input readonly>``` elements in your form styled as plain
 use the ```.form-control-plaintext``` class to remove the default form field styling 
 and preserve the correct margin and padding.
 
-{{< example codeId="code7" class="d-flex justify-content-evenly align-items-center flex-wrap gap-2">}}
+{{< example codeId="code7" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 
 <div class="form-floating">
   <input type="email" class="form-control-plaintext" id="email-read-only-outline"
@@ -225,6 +225,40 @@ and preserve the correct margin and padding.
   <label for="email-read-only-outline-outline">Email</label>
 </div>
         
+{{< /example >}}
+
+## Dark Text Field
+{{< example codeId="code8" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3 bg-dark rounded-top">}}
+
+<div class="form-floating form-floating-dark">
+  <input type="text" class="form-control" id="dark-text"
+         placeholder="dark-text" autocomplete="off">
+  <label for="dark-text">Dark</label>
+</div>
+##split##
+<div class="form-floating form-floating-outlined form-floating-dark">
+  <input type="text" class="form-control" id="dark-text-outlined"
+         placeholder="dark-text-outlined" autocomplete="off">
+  <label for="dark-text-outlined">Dark</label>
+</div>
+
+{{< /example >}}
+
+## Dark Text Field with custom color 
+{{< example codeId="code9" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3 bg-dark rounded-top">}}
+
+<div class="form-floating form-floating-dark base-cyan primary-yellow">
+  <input type="text" class="form-control" id="dark-text-custom"
+         placeholder="dark-text-custom" autocomplete="off">
+  <label for="dark-text-custom">Dark</label>
+</div>
+##split##
+<div class="form-floating form-floating-outlined form-floating-dark base-cyan primary-yellow">
+  <input type="text" class="form-control" id="dark-text-outlined-custom"
+         placeholder="dark-text-outlined-custom" autocomplete="off">
+  <label for="dark-text-outlined-custom">Dark</label>
+</div>
+
 {{< /example >}}
 
 ## Javascript


### PR DESCRIPTION
### Description

Add support for dark Text and Select Fields

### Motivation & Context

Dark input fields can be handy for web pages using dark mode.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/materialstyle/materialstyle/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

* https://deploy-preview-85--materialstyle.netlify.app/3.0/forms/select-fields

### Related issues

Closes #78 
