### PR TITLE
Use css variables to customize colors in Tabs

### DIFF
--- a/scss/_nav.scss
+++ b/scss/_nav.scss
@@ -62,10 +62,11 @@
   --#{$prefix}nav-tabs-link-color: #{$nav-tabs-link-color};
   --#{$prefix}nav-tabs-link-hover-bg: #{$nav-tabs-link-hover-bg};
   --#{$prefix}nav-tabs-link-active-color: #{$nav-tabs-link-active-color};
+  --#{$prefix}nav-tabs-link-active-hover-bg: #{$nav-tabs-link-active-hover-bg};
   --mdc-ripple-hover-opacity: 0;
   --mdc-ripple-focus-opacity: 0;
   --mdc-ripple-press-opacity: .2;
-  --mdc-ripple-color: var(--#{$prefix}nav-tabs-link-active-color);
+  --mdc-ripple-color: var(--#{$prefix}nav-tabs-link-color);
   // scss-docs-end nav-tabs-css-vars
 
   position: relative;
@@ -127,6 +128,8 @@
       box-shadow: none;
 
       &.active {
+        --mdc-ripple-color: var(--#{$prefix}nav-tabs-link-active-color);
+        --#{$prefix}nav-tabs-link-hover-bg: var(--#{$prefix}nav-tabs-link-active-hover-bg);
         color: var(--#{$prefix}nav-tabs-link-active-color);
       }
 
@@ -168,19 +171,6 @@
     height: 2px;
     background: var(--#{$prefix}nav-tabs-link-active-color);
     @include transition(left .2s ease);
-  }
-}
-
-@each $color, $value in $theme-colors {
-  .nav-tabs.primary-#{$color} .nav-link.active,
-  .nav-tabs.base-#{$color} .nav-link:not(.active) {
-    --#{$prefix}nav-tabs-link-color: #{$value} !important; /* stylelint-disable-line declaration-no-important */
-    --#{$prefix}nav-tabs-link-hover-bg: #{rgba($value, .15)};
-    --mdc-ripple-color: #{$value};
-  }
-
-  .nav-tabs.primary-#{$color} {
-    --#{$prefix}nav-tabs-link-active-color: #{$value};
   }
 }
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -889,7 +889,8 @@ $nav-tabs-border-color:             var(--#{$prefix}border-color) !default;
 $nav-tabs-border-width:             var(--#{$prefix}border-width) !default;
 $nav-tabs-link-color:               var(--#{$prefix}body-color) !default;
 $nav-tabs-link-active-color:        var(--#{$prefix}primary-active) !default;
-$nav-tabs-link-hover-bg:            rgba(var(--#{$prefix}primary-rgb), .15) !default;
+$nav-tabs-link-hover-bg:            var(--#{$prefix}primary-subtle) !default;
+$nav-tabs-link-active-hover-bg:     var(--#{$prefix}primary-subtle) !default;
 
 $nav-pills-border-radius:           var(--#{$prefix}border-radius) !default;
 $nav-pills-link-active-color:       $component-active-color !default;

--- a/site/content/3.1/components/tabs.md
+++ b/site/content/3.1/components/tabs.md
@@ -153,9 +153,26 @@ toc: true
 {{< /example >}}
 
 ## Color options
+
+Make use of `--bs-nav-tabs-link-color`, `--bs-nav-tabs-link-hover-bg`, `--bs-nav-tabs-link-active-color` & 
+`--bs-nav-tabs-link-active-hover-bg` css variables to personalize it according to your brand's style.
+
+<div class="d-flex align-items-center bg-danger bg-opacity-25 my-4 rounded-3 overflow-hidden">
+  <div class="d-flex align-items-center align-self-stretch text-bg-danger bg-opacity-100 p-3 fs-4">
+    <i class="bi bi-info-circle-fill"></i>
+  </div>
+  <div class="flex-grow-1 p-3 text-body">
+    Classes <b>.base-[color]</b> & <b>.primary-[color]</b> are depricated in v3.1.0
+  </div>
+</div>
+
 {{< example codeId="code6" >}}
 
-<ul class="nav nav-tabs nav-justified primary-danger base-primary" role="tablist">
+<ul class="nav nav-tabs nav-justified" role="tablist" 
+    style="--bs-nav-tabs-link-color: var(--bs-success-active); 
+           --bs-nav-tabs-link-hover-bg: var(--bs-success-subtle);
+           --bs-nav-tabs-link-active-color: var(--bs-tertiary-hover); 
+           --bs-nav-tabs-link-active-hover-bg: var(--bs-tertiary-subtle); ">
   <li class="nav-item" role="presentation">
     <button class="nav-link" data-bs-toggle="tab" role="tab" data-bs-target="#apple1">Apple</button>
   </li>
@@ -179,7 +196,7 @@ toc: true
 ## Tabs split to multiple rows when there are too many to fit on a row
 {{< example codeId="code7" >}}
 
-<ul class="nav nav-tabs nav-justified base-primary primary-danger" role="tablist">
+<ul class="nav nav-tabs nav-justified" role="tablist">
   <li class="nav-item" role="presentation">
     <button class="nav-link" data-bs-toggle="tab" role="tab" data-bs-target="#apple2">Apple</button>
   </li>
@@ -331,7 +348,11 @@ $('.nav-tabs').materialtab('redraw');
 
 {{< example codeId="code9" >}}
 
-<ul class="nav nav-tabs nav-justified primary-danger base-primary" role="tablist">
+<ul class="nav nav-tabs nav-justified" role="tablist" 
+    style="--bs-nav-tabs-link-color: var(--bs-success-active); 
+           --bs-nav-tabs-link-hover-bg: var(--bs-success-subtle);
+           --bs-nav-tabs-link-active-color: var(--bs-tertiary-hover); 
+           --bs-nav-tabs-link-active-hover-bg: var(--bs-tertiary-subtle); ">
   <li class="nav-item" role="presentation">
     <button class="nav-link" data-bs-toggle="tab" role="tab" data-bs-target="#apple4">
       Apple


### PR DESCRIPTION
### Description

Use css variables to customize colors in Tabs

### Motivation & Context

A wide range of colors can be used if we use CSS variables as opposed to `base-[color]` & `primary-[color]` classes which are limited to `$theme-colors`.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [X] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/materialstyle/materialstyle/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [X] My change introduces changes to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

* https://deploy-preview-95--materialstyle.netlify.app/3.1/components/tabs/#color-options
