### PR TITLE
Add unit to $card-border-width variable

### DIFF
--- a/js/tests/integration/bundle-modularity.js
+++ b/js/tests/integration/bundle-modularity.js
@@ -1,7 +1,7 @@
-/* eslint-disable import/no-unassigned-import */
+/* eslint-disable import/extensions, import/no-unassigned-import */
 
-import Tooltip from '../../dist/tooltip.js'
-import '../../dist/carousel.js'
+import Tooltip from '../../dist/tooltip'
+import '../../dist/carousel'
 
 window.addEventListener('load', () => {
   [].concat(...document.querySelectorAll('[data-bs-toggle="tooltip"]'))

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1049,7 +1049,7 @@ $card-spacer-x:                     $spacer !default;
 $card-title-spacer-y:               $spacer * .5 !default;
 $card-title-color:                  null !default;
 $card-subtitle-color:               null !default;
-$card-border-width:                 0 !default;
+$card-border-width:                 0px !default; // stylelint-disable-line length-zero-no-unit
 $card-border-color:                 var(--#{$prefix}border-color-translucent) !default;
 $card-border-radius:                var(--#{$prefix}border-radius) !default;
 $card-box-shadow:                   null !default;

--- a/site/content/3.1/components/cards.md
+++ b/site/content/3.1/components/cards.md
@@ -115,7 +115,7 @@ toc: true
       Just when the caterpillar thought the world was over, it became a Butterfly.
     </p>
   </div>
-  <div class="d-flex justify-content-between align-items-center flex-wrap p-2 bg-warning bg-opacity-10">
+  <div class="d-flex justify-content-between align-items-center flex-wrap p-2 bg-warning bg-opacity-10 rounded-bottom">
     <div>
       <button type="button" class="btn btn-outline-danger border-0">Read</button>
       <button type="button" class="btn btn-outline-danger border-0">Bookmark</button>


### PR DESCRIPTION
### Description

- Add unit to $card-border-width variable
- Remove file extension from imports in js/tests/integration/bundle-modularity.js

### Motivation & Context

Fixes #97 

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Live previews

* https://deploy-preview-99--materialstyle.netlify.app/materialstyle/3.1/components/cards/

### Related issues

#97 
