### PR TITLE
Use global border-width & border-radius on Selects and Text fields

### DIFF
--- a/js/src/text-field.js
+++ b/js/src/text-field.js
@@ -143,12 +143,10 @@ class TextField extends BaseComponent {
     document.fonts.ready.then(() => {
       if (this._formFloatingWithIcon) {
         if (this._prepend) {
-          this._prepend.style.height = `${this._textField.offsetHeight}px`
           this._formFloating.style.setProperty('--prepend-width', `${this._prepend.offsetWidth}px`)
         }
 
         if (this._append) {
-          this._append.style.height = `${this._textField.offsetHeight}px`
           this._formFloating.style.setProperty('--append-width', `${this._append.offsetWidth}px`)
         }
       }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -576,14 +576,6 @@ $btn-active-bg-shade-amount:      20% !default;
 $btn-active-bg-tint-amount:       20% !default;
 // scss-docs-end btn-variables
 
-
-// Forms
-$form-field-color:                      var(--#{$prefix}emphasis-color) !default;
-$form-field-bg:                         var(--#{$prefix}surface-bg) !default;
-$form-field-hover-bg:                   var(--#{$prefix}surface-bg-hover) !default;
-$form-field-border-color:               var(--#{$prefix}body-color) !default;
-$form-field-active-border-color:        var(--#{$prefix}primary-hover) !default;
-
 // scss-docs-start form-text-variables
 $form-text-margin-top:                  .25rem !default;
 $form-text-font-size:                   $small-font-size !default;
@@ -803,6 +795,15 @@ $form-floating-input-padding-b:   .625rem !default;
 $form-floating-label-opacity:     1 !default;
 $form-floating-label-transform:   scale(.85) translateY(-.5rem) translateX(.15rem) !default;
 $form-floating-transition:        opacity .1s ease-in-out, transform .1s ease-in-out !default;
+
+// Forms
+$form-field-color:                      var(--#{$prefix}emphasis-color) !default;
+$form-field-bg:                         var(--#{$prefix}surface-bg) !default;
+$form-field-hover-bg:                   var(--#{$prefix}surface-bg-hover) !default;
+$form-field-border-width:               var(--#{$prefix}border-width) !default;
+$form-field-border-color:               var(--#{$prefix}body-color) !default;
+$form-field-active-border-color:        var(--#{$prefix}primary-hover) !default;
+$form-field-border-radius:              var(--#{$prefix}border-radius) !default;
 // scss-docs-end form-floating-variables
 
 // Form validation

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -101,7 +101,7 @@
       height: auto;
       min-height: $form-floating-height;
       max-height: 300px;
-      padding: $form-select-padding-y max(calc(var(--append-width, 0px) + $form-select-indicator-padding - 16px), var(--bs-border-radius)) $form-select-padding-y var(--prepend-width, max($form-select-padding-x, var(--bs-border-radius)));
+      padding: $form-select-padding-y calc(var(--append-width, 0px) + $form-select-indicator-padding - 16px) $form-select-padding-y var(--prepend-width, $form-select-padding-x);
       overflow: auto;
       line-height: $form-floating-line-height;
       color: var(--#{$prefix}form-field-color);
@@ -231,7 +231,7 @@
       white-space: normal;
 
       .badge {
-        --bs-badge-color: var(--#{$prefix}form-field-color);
+        --#{$prefix}badge-color: var(--#{$prefix}form-field-color);
 
         .btn-close {
           cursor: pointer;
@@ -297,7 +297,7 @@
 
     > .dropdown.float {
       > .dropdown-toggle {
-        padding: 1.125rem max(calc(var(--append-width, 0px) + $form-select-indicator-padding - 16px), var(--bs-border-radius)) 1.125rem var(--prepend-width, max($form-select-padding-x, var(--bs-border-radius)));
+        padding: 1.125rem calc(var(--append-width, 0px) + $form-select-indicator-padding - 16px) 1.125rem var(--prepend-width, $form-select-padding-x);
       }
     }
 
@@ -378,11 +378,11 @@
   .m-notch-after {
     pointer-events: none;
     border: var(--#{$prefix}form-field-border-width) solid var(--#{$prefix}form-field-border-color);
-    @include border-radius(var(--bs-border-radius));
+    @include border-radius(var(--#{$prefix}form-field-border-radius));
   }
 
   .m-notch-before {
-    width: max(.75rem, var(--bs-border-radius));
+    width: max(.5rem, var(--#{$prefix}form-field-border-radius));
     border-right: 0;
     @include border-top-end-radius(0);
     @include border-bottom-end-radius(0);
@@ -393,7 +393,7 @@
     box-sizing: border-box;
     flex: 0 0 auto;
     width: auto;
-    padding: 0 .75rem;
+    padding: 0 .375rem;
     border-right: 0;
     border-left: 0;
     @include border-radius(0);
@@ -435,13 +435,13 @@
     .form-control,
     .dropdown {
       ~ label {
-        left: var(--prepend-width, 0);
+        left: var(--prepend-width, 0px); // stylelint-disable-line length-zero-no-unit
       }
     }
 
     > .m-notch {
       > .m-notch-between > label {
-        transform: translateX(calc(var(--prepend-width, .75rem) - .75rem));
+        transform: translateX(calc(var(--prepend-width, max(.5rem, var(--#{$prefix}form-field-border-radius))) - max(.5rem, var(--#{$prefix}form-field-border-radius))));
       }
     }
   }

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -3,8 +3,10 @@
   --#{$prefix}form-field-color: #{$form-field-color};
   --#{$prefix}form-field-bg: #{$form-field-bg};
   --#{$prefix}form-field-hover-bg: #{$form-field-hover-bg};
+  --#{$prefix}form-field-border-width: #{$form-field-border-width};
   --#{$prefix}form-field-border-color: #{$form-field-border-color};
   --#{$prefix}form-field-active-border-color: #{$form-field-active-border-color};
+  --#{$prefix}form-field-border-radius: #{$form-field-border-radius};
   --#{$prefix}form-select-indicator: #{escape-svg($form-select-indicator)};
   --#{$prefix}form-select-checkmark: #{escape-svg($form-select-checkmark)};
 
@@ -13,8 +15,8 @@
 
   &:not(.form-floating-outlined) {
     background-color: var(--#{$prefix}form-field-bg);
-    @include border-top-start-radius($border-radius);
-    @include border-top-end-radius($border-radius);
+    @include border-top-start-radius(var(--#{$prefix}form-field-border-radius));
+    @include border-top-end-radius(var(--#{$prefix}form-field-border-radius));
 
     &:hover {
       background-color: var(--#{$prefix}form-field-hover-bg);
@@ -102,7 +104,7 @@
       background-repeat: no-repeat;
       background-position: right var(--append-width, $form-select-padding-x) center;
       background-size: $form-select-bg-size;
-      @include border-radius($border-radius $border-radius 0 0);
+      @include border-radius(var(--#{$prefix}form-field-border-radius) var(--#{$prefix}form-field-border-radius) 0 0);
 
       &::after {
         display: none;
@@ -116,6 +118,7 @@
       --#{$prefix}dropdown-link-active-color: var(--#{$prefix}form-field-color);
       --#{$prefix}dropdown-link-active-bg: var(--#{$prefix}form-field-hover-bg);
       --#{$prefix}dropdown-link-active-hover-bg: var(--#{$prefix}form-field-hover-bg);
+      --#{$prefix}dropdown-border-radius: var(--#{$prefix}form-field-border-radius);
 
       width: 100%;
       max-height: 40vh;
@@ -168,7 +171,7 @@
     }
 
     ~ .m-line-ripple {
-      background-size: 100% 2px, 100% 1px;
+      background-size: 100% calc(var(--#{$prefix}form-field-border-width, 1px) + 1px), 100% var(--#{$prefix}form-field-border-width, 1px);
     }
   }
 
@@ -300,7 +303,7 @@
         > .m-notch-between,
         > .m-notch-after {
           border-color: var(--#{$prefix}form-field-active-border-color);
-          border-width: 2px;
+          border-width: calc(var(--#{$prefix}form-field-border-width, 1px) + 1px);
         }
 
         > .m-notch-between > label {
@@ -340,11 +343,11 @@
 .m-line-ripple {
   position: relative;
   width: 100%;
-  height: 2px;
+  height: calc(var(--#{$prefix}form-field-border-width, 1px) + 1px);
   // stylelint-disable value-list-comma-newline-after, value-list-comma-space-after
   background:
-    linear-gradient(var(--#{$prefix}form-field-active-border-color), var(--#{$prefix}form-field-active-border-color)) bottom/0 2px no-repeat border-box,
-    linear-gradient(var(--#{$prefix}form-field-border-color), var(--#{$prefix}form-field-border-color)) bottom/100% 1px no-repeat border-box transparent;
+    linear-gradient(var(--#{$prefix}form-field-active-border-color), var(--#{$prefix}form-field-active-border-color)) bottom/0 calc(var(--#{$prefix}form-field-border-width, 1px) + 1px) no-repeat border-box,
+    linear-gradient(var(--#{$prefix}form-field-border-color), var(--#{$prefix}form-field-border-color)) bottom/100% var(--#{$prefix}form-field-border-width, 1px) no-repeat border-box transparent;
   // stylelint-enable value-list-comma-newline-after, value-list-comma-space-after
   @include transition(.3s cubic-bezier(.4, 0, .2, 1));
 }
@@ -367,12 +370,12 @@
   .m-notch-between,
   .m-notch-after {
     pointer-events: none;
-    border: 1px solid var(--#{$prefix}form-field-border-color);
-    @include border-radius(.25rem);
+    border: var(--#{$prefix}form-field-border-width) solid var(--#{$prefix}form-field-border-color);
+    @include border-radius(var(--bs-border-radius));
   }
 
   .m-notch-before {
-    width: .75rem;
+    width: max(.75rem, var(--bs-border-radius));
     border-right: 0;
     @include border-top-end-radius(0);
     @include border-bottom-end-radius(0);

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -1,9 +1,13 @@
 // stylelint-disable selector-max-class, selector-max-compound-selectors, selector-no-qualifying-type, function-disallowed-list
+.form-floating,
+.form-floating-with-icon {
+  --#{$prefix}form-field-border-width: #{$form-field-border-width};
+}
+
 .form-floating {
   --#{$prefix}form-field-color: #{$form-field-color};
   --#{$prefix}form-field-bg: #{$form-field-bg};
   --#{$prefix}form-field-hover-bg: #{$form-field-hover-bg};
-  --#{$prefix}form-field-border-width: #{$form-field-border-width};
   --#{$prefix}form-field-border-color: #{$form-field-border-color};
   --#{$prefix}form-field-active-border-color: #{$form-field-active-border-color};
   --#{$prefix}form-field-border-radius: #{$form-field-border-radius};
@@ -35,6 +39,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     pointer-events: none;
+    border: var(--#{$prefix}form-field-border-width) solid transparent; // Required for aligning label's text with the input as it affects inner box model
     transform-origin: 0 0;
     @include transition($form-floating-transition);
   }
@@ -46,7 +51,7 @@
     line-height: $form-floating-line-height;
     color: var(--#{$prefix}form-field-color);
     background-color: transparent;
-    border: 0;
+    border: var(--#{$prefix}form-field-border-width) solid transparent;
     @include border-bottom-end-radius(0);
     @include border-bottom-start-radius(0);
     box-shadow: none;
@@ -94,9 +99,9 @@
       display: block;
       width: 100%;
       height: auto;
-      min-height: 60px;
+      min-height: $form-floating-height;
       max-height: 300px;
-      padding: $form-select-padding-y calc(var(--append-width, 0px) + $form-select-indicator-padding) $form-select-padding-y var(--prepend-width, $form-select-padding-x);
+      padding: $form-select-padding-y max(calc(var(--append-width, 0px) + $form-select-indicator-padding - 16px), var(--bs-border-radius)) $form-select-padding-y var(--prepend-width, max($form-select-padding-x, var(--bs-border-radius)));
       overflow: auto;
       line-height: $form-floating-line-height;
       color: var(--#{$prefix}form-field-color);
@@ -104,6 +109,7 @@
       background-repeat: no-repeat;
       background-position: right var(--append-width, $form-select-padding-x) center;
       background-size: $form-select-bg-size;
+      border: var(--#{$prefix}form-field-border-width) solid transparent;
       @include border-radius(var(--#{$prefix}form-field-border-radius) var(--#{$prefix}form-field-border-radius) 0 0);
 
       &::after {
@@ -291,7 +297,7 @@
 
     > .dropdown.float {
       > .dropdown-toggle {
-        padding: 1.125rem calc(var(--append-width, 0px) + $form-select-indicator-padding) 1.125rem var(--prepend-width, $form-select-padding-x);
+        padding: 1.125rem max(calc(var(--append-width, 0px) + $form-select-indicator-padding - 16px), var(--bs-border-radius)) 1.125rem var(--prepend-width, max($form-select-padding-x, var(--bs-border-radius)));
       }
     }
 
@@ -341,7 +347,8 @@
 
 // Ripple and Notch
 .m-line-ripple {
-  position: relative;
+  position: absolute;
+  bottom: 0;
   width: 100%;
   height: calc(var(--#{$prefix}form-field-border-width, 1px) + 1px);
   // stylelint-disable value-list-comma-newline-after, value-list-comma-space-after
@@ -386,7 +393,7 @@
     box-sizing: border-box;
     flex: 0 0 auto;
     width: auto;
-    padding: 0 5px;
+    padding: 0 .75rem;
     border-right: 0;
     border-left: 0;
     @include border-radius(0);
@@ -411,16 +418,17 @@
     top: 0;
     display: flex;
     align-items: center;
+    height: $form-floating-height;
     padding: 0 .75rem;
     pointer-events: none;
   }
 
   .prepend {
-    left: 0;
+    left: var(--#{$prefix}form-field-border-width);
   }
 
   .append {
-    right: 0;
+    right: var(--#{$prefix}form-field-border-width);
   }
 
   > .form-floating {
@@ -433,7 +441,7 @@
 
     > .m-notch {
       > .m-notch-between > label {
-        transform: translateX(calc(var(--prepend-width, calc(.75rem + 5px)) - (.75rem + 5px)));
+        transform: translateX(calc(var(--prepend-width, .75rem) - .75rem));
       }
     }
   }

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -105,16 +105,37 @@
     > .form-floating:not(:last-child) > .form-select {
       @include border-end-radius(0);
     }
+
+    &.has-form-floating-outlined {
+      > .input-group-text:not(:first-child) {
+        border-left: 0;
+      }
+      > .input-group-text:not(:last-child) {
+        border-right: 0;
+      }
+    }
   }
 
+  // stylelint-disable selector-max-class
   &.has-validation {
     > :nth-last-child(n + 3):not(.dropdown-toggle):not(.dropdown-menu),
     > .dropdown-toggle:nth-last-child(n + 4),
+    > .form-floating:nth-last-child(n + 3) > .m-notch > .m-notch-after,
     > .form-floating:nth-last-child(n + 3) > .form-control,
     > .form-floating:nth-last-child(n + 3) > .form-select {
       @include border-end-radius(0);
     }
+
+    &.has-form-floating-outlined {
+      > .input-group-text:not(:first-child) {
+        border-left: 0;
+      }
+      > .input-group-text:nth-last-child(n + 3) {
+        border-right: 0;
+      }
+    }
   }
+  // stylelint-enable selector-max-class
 
   $validation-messages: "";
   @each $state in map-keys($form-validation-states) {
@@ -152,15 +173,6 @@
 
     > .input-group-text:not(:last-child) {
       padding-left: calc(#{$input-border-width} + #{$input-group-addon-padding-x}); // stylelint-disable-line function-disallowed-list
-    }
-  }
-
-  &.has-form-floating-outlined {
-    > .input-group-text:not(:first-child) {
-      border-left: 0;
-    }
-    > .input-group-text:not(:last-child) {
-      border-right: 0;
     }
   }
 }

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -125,7 +125,6 @@
   > .form-floating:not(:first-child) > .m-notch > .m-notch-before,
   > .form-floating:not(:first-child) > .form-control,
   > .form-floating:not(:first-child) > .form-select {
-    margin-left: calc(#{$input-border-width} * -1); // stylelint-disable-line function-disallowed-list
     @include border-start-radius(0);
   }
 
@@ -141,6 +140,14 @@
       border-top: 0;
       border-right: 0;
       border-left: 0;
+    }
+
+    > .input-group-text:not(:first-child) {
+      padding-right: calc(#{$input-border-width} + #{$input-group-addon-padding-x}); // stylelint-disable-line function-disallowed-list
+    }
+
+    > .input-group-text:not(:last-child) {
+      padding-left: calc(#{$input-border-width} + #{$input-group-addon-padding-x}); // stylelint-disable-line function-disallowed-list
     }
   }
 

--- a/scss/forms/_input-group.scss
+++ b/scss/forms/_input-group.scss
@@ -128,6 +128,10 @@
     @include border-start-radius(0);
   }
 
+  > .form-floating:not(:first-child) > .m-notch > .m-notch-before {
+    width: .5rem;
+  }
+
   &.has-form-floating {
     > .form-control,
     > .form-select,

--- a/scss/mixins/_forms.scss
+++ b/scss/mixins/_forms.scss
@@ -117,6 +117,7 @@
       @include form-validation-state-selector($state) {
         padding-right: calc($input-height-inner + var(--append-width, 0px));
         background-position: right var(--append-width, $input-height-inner-quarter) center;
+        border-color: transparent;
 
         &:focus {
           box-shadow: none;

--- a/site/content/3.1/forms/select-fields.md
+++ b/site/content/3.1/forms/select-fields.md
@@ -292,7 +292,7 @@ Add class ```searchable``` on ```.form-floating``` to add a search box to the me
 {{< /example >}}
 
 ## Multi Select
-Add class ```multi-select``` on ```.form-floating``` to enable multi select.
+Add class ```multi-select``` on ```.form-floating``` and ```multiple``` attribute on the ```<select>``` to enable multi select.
 
 {{< example codeId="code7" class="d-flex justify-content-evenly align-items-center flex-wrap gap-3">}}
 

--- a/site/content/3.1/forms/validation.md
+++ b/site/content/3.1/forms/validation.md
@@ -57,36 +57,22 @@ better communicate feedback.
 
   <div>
     <div class="form-floating">
-      <input type="text" class="form-control" id="textfield" placeholder="textfield" autocomplete="off" required>
-      <label for="textfield">Text Field</label>
+      <input type="text" class="form-control" id="textFieldExample" placeholder="textField" autocomplete="off" required>
+      <label for="textFieldExample">Text Field</label>
     </div>
-    <div class="valid-feedback">Looks good!</div>
-    <div class="invalid-feedback">Doesn't look good!</div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
   </div>
-
+  
   <div>
     <div class="form-floating form-floating-outlined">
-      <input type="text" class="form-control" id="textfieldOutlined" placeholder="textfield" autocomplete="off" required>
-      <label for="textfieldOutlined">Outlined Text Field</label>
+      <input type="text" class="form-control" id="textFieldOutlinedExample" placeholder="textField" autocomplete="off" required>
+      <label for="textFieldOutlinedExample">Outlined Text Field</label>
     </div>
-    <div class="valid-feedback">Looks good!</div>
-    <div class="invalid-feedback">Doesn't look good!</div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
   </div>
-
-  <div class="input-group has-validation">
-    <div class="form-floating">
-      <input type="text" class="form-control" id="inputgroup" placeholder="inputgroup" autocomplete="off" required>
-      <label for="inputgroup">Input Group</label>
-    </div>
-    <span class="input-group-text">
-      <i class="bi bi-person-circle"></i>
-    </span>
-    <div class="validation-feedbacks">
-      <div class="valid-feedback">Looks good!</div>
-      <div class="invalid-feedback">Doesn't look good!</div>
-    </div>
-  </div>
-
+  
   <div>
     <div class="form-floating">
       <select class="form-select" required>
@@ -98,8 +84,8 @@ better communicate feedback.
       </select>
       <label>Select</label>
     </div>
-    <div class="valid-feedback">Looks good!</div>
-    <div class="invalid-feedback">Doesn't look good!</div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
   </div>
 
   <div>
@@ -113,9 +99,188 @@ better communicate feedback.
       </select>
       <label>Outlined Select</label>
     </div>
-    <div class="valid-feedback">Looks good!</div>
-    <div class="invalid-feedback">Doesn't look good!</div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
   </div>
+
+  <div class="w-100"></div>
+  
+  <button class="btn btn-primary" type="submit">Submit form</button>
+</form>
+
+{{< /example >}}
+
+## Supported Components
+
+{{< example codeId="code2">}}
+
+<form class="needs-validation d-flex flex-wrap gap-2" novalidate>
+
+  <label class="w-100 text-primary"><b>Text field</b></label>
+
+  <div>
+    <div class="form-floating">
+      <input type="text" class="form-control" id="textField" placeholder="textField" autocomplete="off" required>
+      <label for="textField">Text Field</label>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
+  </div>
+
+  <div>
+    <div class="form-floating form-floating-outlined">
+      <input type="text" class="form-control" id="textFieldOutlined" placeholder="textField" autocomplete="off" required>
+      <label for="textFieldOutlined">Outlined Text Field</label>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
+  </div>
+  
+  <label class="w-100 text-primary"><b>Input group</b></label>
+
+  <div class="input-group has-validation">
+    <div class="form-floating">
+      <input type="text" class="form-control" id="inputGroup" placeholder="inputGroup" autocomplete="off" required>
+      <label for="inputGroup">Input Group</label>
+    </div>
+    <span class="input-group-text">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="validation-feedbacks">
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please fill in this field</div>
+    </div>
+  </div>
+  
+  <div class="input-group has-validation">
+    <div class="form-floating form-floating-outlined">
+      <input type="text" class="form-control" id="inputGroupOutlined" placeholder="inputGroup" autocomplete="off" required>
+      <label for="inputGroupOutlined">Input Group</label>
+    </div>
+    <span class="input-group-text">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="validation-feedbacks">
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please fill in this field</div>
+    </div>
+  </div>
+  
+  <div class="input-group has-validation">
+    <span class="input-group-text">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="form-floating">
+      <input type="text" class="form-control" id="inputGroupPrepend" placeholder="inputGroup" autocomplete="off" required>
+      <label for="inputGroupPrepend">Input Group</label>
+    </div>
+    <div class="validation-feedbacks">
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please fill in this field</div>
+    </div>
+  </div>
+  
+  <div class="input-group has-validation">
+    <span class="input-group-text">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="form-floating form-floating-outlined">
+      <input type="text" class="form-control" id="inputGroupOutlinedPrepend" placeholder="inputGroup" autocomplete="off" required>
+      <label for="inputGroupOutlinedPrepend">Input Group</label>
+    </div>
+    <div class="validation-feedbacks">
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please fill in this field</div>
+    </div>
+  </div>
+  
+  <label class="w-100 text-primary"><b>With icon</b></label>
+  
+  <div class="form-floating-with-icon">
+    <div class="form-floating">
+      <input type="text" class="form-control" id="withIcon"
+             placeholder="withIcon" autocomplete="off" required>
+      <label for="withIcon">With Icon</label>
+    </div>
+    <span class="prepend">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
+  </div>
+  
+  <div class="form-floating-with-icon">
+    <div class="form-floating form-floating-outlined">
+      <input type="text" class="form-control" id="withIconOutlined"
+             placeholder="withIcon" autocomplete="off" required>
+      <label for="withIconOutlined">With Icon</label>
+    </div>
+    <span class="prepend">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
+  </div>
+
+  <div class="form-floating-with-icon">
+    <div class="form-floating">
+      <input type="text" class="form-control" id="withIconAppend"
+             placeholder="withIcon" autocomplete="off" required>
+      <label for="withIconAppend">With Icon</label>
+    </div>
+    <span class="append">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
+  </div>
+  
+  <div class="form-floating-with-icon">
+    <div class="form-floating form-floating-outlined">
+      <input type="text" class="form-control" id="withIconOutlinedAppend"
+             placeholder="withIcon" autocomplete="off" required>
+      <label for="withIconOutlinedAppend">With Icon</label>
+    </div>
+    <span class="append">
+      <i class="bi bi-person-circle"></i>
+    </span>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please fill in this field</div>
+  </div>
+
+  <label class="w-100 text-primary"><b>Select</b></label>
+
+  <div>
+    <div class="form-floating">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>Select</label>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
+  </div>
+
+  <div>
+    <div class="form-floating form-floating-outlined">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>Outlined Select</label>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
+  </div>
+
+  <label class="w-100 text-primary"><b>Input group</b></label>
 
   <div class="input-group has-validation">
     <div class="form-floating">
@@ -126,24 +291,197 @@ better communicate feedback.
         <option value="3">Option 3</option>
         <option value="4">Option 4</option>
       </select>
-      <label>Select with Input Group</label>
+      <label>Input Group</label>
     </div>
     <div class="input-group-text">
       <i class="bi bi-star-fill"></i>
     </div>
     <div class="validation-feedbacks">
-      <div class="valid-feedback">Looks good!</div>
-      <div class="invalid-feedback">Doesn't look good!</div>
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please select an item in the list</div>
     </div>
   </div>
 
-  <div class="form-check w-100">
-    <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
-    <label class="form-check-label" for="invalidCheck">
-      Agree to terms and conditions
-    </label>
-    <div class="invalid-feedback">
-      You must agree before submitting.
+  <div class="input-group has-validation">
+    <div class="form-floating form-floating-outlined">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>Input Group</label>
+    </div>
+    <div class="input-group-text">
+      <i class="bi bi-star-fill"></i>
+    </div>
+    <div class="validation-feedbacks">
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please select an item in the list</div>
+    </div>
+  </div>
+
+  <div class="input-group has-validation">
+    <div class="input-group-text">
+      <i class="bi bi-star-fill"></i>
+    </div>
+    <div class="form-floating">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>Input Group</label>
+    </div>
+    <div class="validation-feedbacks">
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please select an item in the list</div>
+    </div>
+  </div>
+
+  <div class="input-group has-validation">
+    <div class="input-group-text">
+      <i class="bi bi-star-fill"></i>
+    </div>
+    <div class="form-floating form-floating-outlined">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>Input Group</label>
+    </div>
+    <div class="validation-feedbacks">
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please select an item in the list</div>
+    </div>
+  </div>
+  
+  <label class="w-100 text-primary"><b>With icon</b></label>
+
+  <div class="form-floating-with-icon">
+    <div class="form-floating">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>With icon</label>
+    </div>
+    <div class="prepend">
+      <i class="bi bi-star-fill"></i>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
+  </div>
+
+  <div class="form-floating-with-icon">
+    <div class="form-floating form-floating-outlined">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>With icon</label>
+    </div>
+    <div class="prepend">
+      <i class="bi bi-star-fill"></i>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
+  </div>
+
+  <div class="form-floating-with-icon">
+    <div class="form-floating">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>With icon</label>
+    </div>
+    <div class="append">
+      <i class="bi bi-star-fill"></i>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
+  </div>
+
+  <div class="form-floating-with-icon">
+    <div class="form-floating form-floating-outlined">
+      <select class="form-select" required>
+        <option value="" label="blank option"></option>
+        <option value="1">Option 1</option>
+        <option value="2">Option 2</option>
+        <option value="3">Option 3</option>
+        <option value="4">Option 4</option>
+      </select>
+      <label>With icon</label>
+    </div>
+    <div class="append">
+      <i class="bi bi-star-fill"></i>
+    </div>
+    <div class="valid-feedback">Valid</div>
+    <div class="invalid-feedback">Please select an item in the list</div>
+  </div>
+
+  <label class="w-100 text-primary"><b>Checks and Radios</b></label>
+
+  <div class="w-100 d-flex gap-3">
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="" id="invalidCheck" required>
+      <label class="form-check-label" for="invalidCheck">
+        Checkbox
+      </label>
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please tick this box</div>
+    </div>
+
+    <div>
+      <div class="form-check">
+        <input class="form-check-input" type="radio" name="radioSet1" id="radio1" required>
+        <label class="form-check-label" for="radio1">Radio</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input" type="radio" name="radioSet1" id="radio2" required>
+        <label class="form-check-label" for="radio2">Radio</label>
+        <div class="valid-feedback">Valid</div>
+        <div class="invalid-feedback">Please select one of these options</div>
+      </div>
+    </div>
+    
+    <div>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" id="switch1" required>
+      <label class="form-check-label" for="switch1">Switch</label>
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please tick this box</div>
+    </div>
+
+    <div class="form-check form-switch form-switch-square">
+      <input class="form-check-input" type="checkbox" id="switch5" required>
+      <label class="form-check-label" for="switch5">Switch</label>
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please tick this box</div>
+    </div>
+
+    <div class="form-check form-switch form-switch-material">
+      <input class="form-check-input" type="checkbox" id="switch9" required>
+      <label class="form-check-label" for="switch9">Switch</label>
+      <div class="valid-feedback">Valid</div>
+      <div class="invalid-feedback">Please tick this box</div>
+    </div>
     </div>
   </div>
 
@@ -221,40 +559,26 @@ If your form layout allows it, you can swap the ```.{valid|invalid}-feedback``` 
 for ```.{valid|invalid}-tooltip``` classes to display validation feedback in a styled tooltip. 
 Be sure to have a parent with ```position: relative``` on it for tooltip positioning.
 
-{{< example codeId="code2">}}
+{{< example codeId="code3">}}
 
 <form class="needs-validation d-flex flex-wrap gap-2" novalidate>
 
-  <div class="position-relative mb-5">
+  <div class="position-relativ mb-5">
     <div class="form-floating">
-      <input type="text" class="form-control" id="textfieldTooltip" placeholder="textfield" autocomplete="off" required>
+      <input type="text" class="form-control" id="textfieldTooltip" placeholder="textField" autocomplete="off" required>
       <label for="textfieldTooltip">Text Field</label>
     </div>
-    <div class="valid-tooltip">Looks good!</div>
-    <div class="invalid-tooltip">Doesn't look good!</div>
+    <div class="valid-tooltip">Valid</div>
+    <div class="invalid-tooltip">Invalid</div>
   </div>
 
   <div class="position-relative mb-5">
     <div class="form-floating form-floating-outlined">
-      <input type="text" class="form-control" id="textfieldOutlinedTooltip" placeholder="textfield" autocomplete="off" required>
+      <input type="text" class="form-control" id="textfieldOutlinedTooltip" placeholder="textField" autocomplete="off" required>
       <label for="textfieldOutlinedTooltip">Outlined Text Field</label>
     </div>
-    <div class="valid-tooltip">Looks good!</div>
-    <div class="invalid-tooltip">Doesn't look good!</div>
-  </div>
-
-  <div class="input-group has-validation position-relative mb-5">
-    <div class="form-floating">
-      <input type="text" class="form-control" id="inputgroupTooltip" placeholder="inputgroup" autocomplete="off" required>
-      <label for="inputgroupTooltip">Input Group</label>
-    </div>
-    <span class="input-group-text">
-      <i class="bi bi-person-circle"></i>
-    </span>
-    <div class="validation-feedbacks">
-      <div class="valid-tooltip">Looks good!</div>
-      <div class="invalid-tooltip">Doesn't look good!</div>
-    </div>
+    <div class="valid-tooltip">Valid</div>
+    <div class="invalid-tooltip">Invalid</div>
   </div>
 
   <div class="position-relative mb-5">
@@ -268,8 +592,8 @@ Be sure to have a parent with ```position: relative``` on it for tooltip positio
       </select>
       <label>Select</label>
     </div>
-    <div class="valid-tooltip">Looks good!</div>
-    <div class="invalid-tooltip">Doesn't look good!</div>
+    <div class="valid-tooltip">Valid</div>
+    <div class="invalid-tooltip">Invalid</div>
   </div>
 
   <div class="position-relative mb-5">
@@ -283,40 +607,12 @@ Be sure to have a parent with ```position: relative``` on it for tooltip positio
       </select>
       <label>Outlined Select</label>
     </div>
-    <div class="valid-tooltip">Looks good!</div>
-    <div class="invalid-tooltip">Doesn't look good!</div>
+    <div class="valid-tooltip">Valid</div>
+    <div class="invalid-tooltip">Invalid</div>
   </div>
-
-  <div class="input-group has-validation position-relative mb-5">
-    <div class="form-floating">
-      <select class="form-select" required>
-        <option value="" label="blank option"></option>
-        <option value="1">Option 1</option>
-        <option value="2">Option 2</option>
-        <option value="3">Option 3</option>
-        <option value="4">Option 4</option>
-      </select>
-      <label>Select with Input Group</label>
-    </div>
-    <div class="input-group-text">
-      <i class="bi bi-star-fill"></i>
-    </div>
-    <div class="validation-feedbacks">
-      <div class="valid-tooltip">Looks good!</div>
-      <div class="invalid-tooltip">Doesn't look good!</div>
-    </div>
-  </div>
-
-  <div class="form-check w-100 position-relative mb-5">
-    <input class="form-check-input" type="checkbox" value="" id="invalidCheckTooltip" required>
-    <label class="form-check-label" for="invalidCheckTooltip">
-      Agree to terms and conditions
-    </label>
-    <div class="invalid-tooltip">
-      You must agree before submitting.
-    </div>
-  </div>
-
+  
+  <div class="w-100"></div>
+    
   <button class="btn btn-primary" type="submit">Submit form</button>
 </form>
 
@@ -331,28 +627,18 @@ Depending on your browser and OS, you’ll see a slightly different style of fee
 While these feedback styles cannot be styled with CSS, you can still customize the feedback 
 text through JavaScript.
 
-{{< example codeId="code3">}}
+{{< example codeId="code4">}}
 
 <form class="d-flex flex-wrap gap-2">
 
   <div class="form-floating">
-    <input type="text" class="form-control" id="textfieldDefault" placeholder="textfield" autocomplete="off" required>
+    <input type="text" class="form-control" id="textfieldDefault" placeholder="textField" autocomplete="off" required>
     <label for="textfieldDefault">Text Field</label>
   </div>
 
   <div class="form-floating form-floating-outlined">
-    <input type="text" class="form-control" id="textfieldOutlinedDefault" placeholder="textfield" autocomplete="off" required>
+    <input type="text" class="form-control" id="textfieldOutlinedDefault" placeholder="textField" autocomplete="off" required>
     <label for="textfieldOutlinedDefault">Outlined Text Field</label>
-  </div>
-
-  <div class="input-group">
-    <div class="form-floating">
-      <input type="text" class="form-control" id="inputgroupDefault" placeholder="inputgroup" autocomplete="off" required>
-      <label for="inputgroupDefault">Input Group</label>
-    </div>
-    <span class="input-group-text">
-      <i class="bi bi-person-circle"></i>
-    </span>
   </div>
 
   <div class="form-floating">
@@ -377,29 +663,8 @@ text through JavaScript.
     <label>Outlined Select</label>
   </div>
 
-  <div class="input-group">
-    <div class="form-floating">
-      <select class="form-select" required>
-        <option value="" label="blank option"></option>
-        <option value="1">Option 1</option>
-        <option value="2">Option 2</option>
-        <option value="3">Option 3</option>
-        <option value="4">Option 4</option>
-      </select>
-      <label>Select with Input Group</label>
-    </div>
-    <div class="input-group-text">
-      <i class="bi bi-star-fill"></i>
-    </div>
-  </div>
-
-  <div class="form-check w-100">
-    <input class="form-check-input" type="checkbox" value="" id="invalidCheckDefault" required>
-    <label class="form-check-label" for="invalidCheckDefault">
-      Agree to terms and conditions
-    </label>
-  </div>
-
+  <div class="w-100"></div>
+  
   <button class="btn btn-primary" type="submit">Submit form</button>
 </form>
 


### PR DESCRIPTION
### Description

Use global border-width & border-radius on Selects and Text fields

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/materialstyle/materialstyle/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

* https://deploy-preview-100--materialstyle.netlify.app/materialstyle/3.1/forms/text-fields/
