### PR TITLE
Don't change the visibility of the offcanvas toggler based on navbar-expand-* breakpoints

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,6 +51,7 @@
         "SwitchCase": 1
       }
     ],
+    "logical-assignment-operators": "off",
     "max-params": [
       "warn",
       5
@@ -75,6 +76,7 @@
       "error",
       "after"
     ],
+    "prefer-object-has-own": "off",
     "prefer-template": "error",
     "semi": [
       "error",
@@ -83,6 +85,7 @@
     "strict": "error",
     "unicorn/explicit-length-check": "off",
     "unicorn/filename-case": "off",
+    "unicorn/no-anonymous-default-export": "off",
     "unicorn/no-array-callback-reference": "off",
     "unicorn/no-array-method-this-argument": "off",
     "unicorn/no-null": "off",
@@ -95,7 +98,9 @@
     "unicorn/prefer-module": "off",
     "unicorn/prefer-query-selector": "off",
     "unicorn/prefer-spread": "off",
+    "unicorn/prefer-string-raw": "off",
     "unicorn/prefer-string-replace-all": "off",
+    "unicorn/prefer-structured-clone": "off",
     "unicorn/prevent-abbreviations": "off"
   },
   "overrides": [
@@ -197,6 +202,15 @@
     },
     {
       "files": [
+        "site/assets/js/**"
+      ],
+      "parserOptions": {
+        "sourceType": "module",
+        "ecmaVersion": 2020
+      }
+    },
+    {
+      "files": [
         "**/*.md"
       ],
       "plugins": [
@@ -206,9 +220,10 @@
     },
     {
       "files": [
-        "**/*.md/*.js"
+        "**/*.md/*.js",
+        "**/*.md/*.mjs"
       ],
-      "extends": "plugin:markdown/recommended",
+      "extends": "plugin:markdown/recommended-legacy",
       "parserOptions": {
         "sourceType": "module"
       },

--- a/js/src/modal.js
+++ b/js/src/modal.js
@@ -11,7 +11,9 @@ import SelectorEngine from './dom/selector-engine.js'
 import Backdrop from './util/backdrop.js'
 import { enableDismissTrigger } from './util/component-functions.js'
 import FocusTrap from './util/focustrap.js'
-import { defineJQueryPlugin, isRTL, isVisible, reflow } from './util/index.js'
+import {
+  defineJQueryPlugin, isRTL, isVisible, reflow
+} from './util/index.js'
 import ScrollBarHelper from './util/scrollbar.js'
 
 /**

--- a/js/src/scrollspy.js
+++ b/js/src/scrollspy.js
@@ -8,7 +8,9 @@
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import SelectorEngine from './dom/selector-engine.js'
-import { defineJQueryPlugin, getElement, isDisabled, isVisible } from './util/index.js'
+import {
+  defineJQueryPlugin, getElement, isDisabled, isVisible
+} from './util/index.js'
 
 /**
  * Constants

--- a/js/src/tooltip.js
+++ b/js/src/tooltip.js
@@ -9,7 +9,9 @@ import * as Popper from '@popperjs/core'
 import BaseComponent from './base-component.js'
 import EventHandler from './dom/event-handler.js'
 import Manipulator from './dom/manipulator.js'
-import { defineJQueryPlugin, execute, findShadowRoot, getElement, getUID, isRTL, noop } from './util/index.js'
+import {
+  defineJQueryPlugin, execute, findShadowRoot, getElement, getUID, isRTL, noop
+} from './util/index.js'
 import { DefaultAllowlist } from './util/sanitizer.js'
 import TemplateFactory from './util/template-factory.js'
 

--- a/js/src/util/backdrop.js
+++ b/js/src/util/backdrop.js
@@ -7,7 +7,9 @@
 
 import EventHandler from '../dom/event-handler.js'
 import Config from './config.js'
-import { execute, executeAfterTransition, getElement, reflow } from './index.js'
+import {
+  execute, executeAfterTransition, getElement, reflow
+} from './index.js'
 
 /**
  * Constants

--- a/js/tests/unit/carousel.spec.js
+++ b/js/tests/unit/carousel.spec.js
@@ -2,7 +2,9 @@ import Carousel from '../../src/carousel.js'
 import EventHandler from '../../src/dom/event-handler.js'
 import { isRTL, noop } from '../../src/util/index.js'
 import Swipe from '../../src/util/swipe.js'
-import { clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture.js'
+import {
+  clearFixture, createEvent, getFixture, jQueryMock
+} from '../helpers/fixture.js'
 
 describe('Carousel', () => {
   const { Simulator, PointerEvent } = window

--- a/js/tests/unit/dropdown.spec.js
+++ b/js/tests/unit/dropdown.spec.js
@@ -1,7 +1,9 @@
 import EventHandler from '../../src/dom/event-handler.js'
 import Dropdown from '../../src/dropdown.js'
 import { noop } from '../../src/util/index.js'
-import { clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture.js'
+import {
+  clearFixture, createEvent, getFixture, jQueryMock
+} from '../helpers/fixture.js'
 
 describe('Dropdown', () => {
   let fixtureEl

--- a/js/tests/unit/offcanvas.spec.js
+++ b/js/tests/unit/offcanvas.spec.js
@@ -2,7 +2,9 @@ import EventHandler from '../../src/dom/event-handler.js'
 import Offcanvas from '../../src/offcanvas.js'
 import { isVisible } from '../../src/util/index.js'
 import ScrollBarHelper from '../../src/util/scrollbar.js'
-import { clearBodyAndDocument, clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture.js'
+import {
+  clearBodyAndDocument, clearFixture, createEvent, getFixture, jQueryMock
+} from '../helpers/fixture.js'
 
 describe('Offcanvas', () => {
   let fixtureEl

--- a/js/tests/unit/scrollspy.spec.js
+++ b/js/tests/unit/scrollspy.spec.js
@@ -1,6 +1,8 @@
 import EventHandler from '../../src/dom/event-handler.js'
 import ScrollSpy from '../../src/scrollspy.js'
-import { clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture.js'
+import {
+  clearFixture, createEvent, getFixture, jQueryMock
+} from '../helpers/fixture.js'
 
 describe('ScrollSpy', () => {
   let fixtureEl

--- a/js/tests/unit/tab.spec.js
+++ b/js/tests/unit/tab.spec.js
@@ -1,5 +1,7 @@
 import Tab from '../../src/tab.js'
-import { clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture.js'
+import {
+  clearFixture, createEvent, getFixture, jQueryMock
+} from '../helpers/fixture.js'
 
 describe('Tab', () => {
   let fixtureEl

--- a/js/tests/unit/toast.spec.js
+++ b/js/tests/unit/toast.spec.js
@@ -1,5 +1,7 @@
 import Toast from '../../src/toast.js'
-import { clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture.js'
+import {
+  clearFixture, createEvent, getFixture, jQueryMock
+} from '../helpers/fixture.js'
 
 describe('Toast', () => {
   let fixtureEl

--- a/js/tests/unit/tooltip.spec.js
+++ b/js/tests/unit/tooltip.spec.js
@@ -1,7 +1,9 @@
 import EventHandler from '../../src/dom/event-handler.js'
 import Tooltip from '../../src/tooltip.js'
 import { noop } from '../../src/util/index.js'
-import { clearFixture, createEvent, getFixture, jQueryMock } from '../helpers/fixture.js'
+import {
+  clearFixture, createEvent, getFixture, jQueryMock
+} from '../helpers/fixture.js'
 
 describe('Tooltip', () => {
   let fixtureEl

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "css-rtl": "cross-env NODE_ENV=RTL postcss --config build/postcss.config.mjs --dir \"dist/css\" --ext \".rtl.css\" \"dist/css/*.css\" \"!dist/css/*.min.css\" \"!dist/css/*.rtl.css\"",
     "css-lint": "npm-run-all --aggregate-output --continue-on-error --parallel css-lint-*",
     "css-lint-stylelint": "stylelint \"**/*.{css,scss}\" --cache --cache-location .cache/.stylelintcache",
-    "css-lint-vars": "fusv scss/ site/assets/scss/",
+    "css-lint-vars": "fusv scss/ site/assets/**/scss/",
     "css-minify": "npm-run-all --aggregate-output --parallel css-minify-*",
     "css-minify-main": "cleancss -O1 --format breakWith=lf --with-rebase --source-map --source-map-inline-sources --output dist/css/ --batch --batch-suffix \".min\" \"dist/css/*.css\" \"!dist/css/*.min.css\" \"!dist/css/*rtl*.css\"",
     "css-minify-rtl": "cleancss -O1 --format breakWith=lf --with-rebase --source-map --source-map-inline-sources --output dist/css/ --batch --batch-suffix \".min\" \"dist/css/*rtl.css\" \"!dist/css/*.min.css\"",

--- a/scss/_navbar.scss
+++ b/scss/_navbar.scss
@@ -231,7 +231,7 @@
           flex-basis: auto;
         }
 
-        .navbar-toggler {
+        .navbar-toggler:not([data-bs-toggle="offcanvas"]) {
           display: none;
         }
 

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -351,11 +351,11 @@
   bottom: 0;
   width: 100%;
   height: calc(var(--#{$prefix}form-field-border-width, 1px) + 1px);
-  // stylelint-disable stylistic/value-list-comma-newline-after, stylistic/value-list-comma-space-after
+  // stylelint-disable @stylistic/value-list-comma-newline-after, @stylistic/value-list-comma-space-after
   background:
     linear-gradient(var(--#{$prefix}form-field-active-border-color), var(--#{$prefix}form-field-active-border-color)) bottom/0 calc(var(--#{$prefix}form-field-border-width, 1px) + 1px) no-repeat border-box,
     linear-gradient(var(--#{$prefix}form-field-border-color), var(--#{$prefix}form-field-border-color)) bottom/100% var(--#{$prefix}form-field-border-width, 1px) no-repeat border-box transparent;
-  // stylelint-enable stylistic/value-list-comma-newline-after, stylistic/value-list-comma-space-after
+  // stylelint-enable @stylistic/value-list-comma-newline-after, @stylistic/value-list-comma-space-after
   @include transition(.3s cubic-bezier(.4, 0, .2, 1));
 }
 

--- a/scss/tests/mixins/_utilities.test.scss
+++ b/scss/tests/mixins/_utilities.test.scss
@@ -258,7 +258,7 @@ $enable-important-utilities: false;
           .desaturated-color-blue {
             --bs-color-opacity: 1;
             // Sass compilation will put a leading zero so we want to keep that one
-            // stylelint-disable-next-line stylistic/number-leading-zero
+            // stylelint-disable-next-line @stylistic/number-leading-zero
             --bs-color-saturation: 0.25;
             color: hsla(192deg, var(--bs-color-saturation), 0, var(--bs-color-opacity));
           }

--- a/site/content/3.1/components/drawer.md
+++ b/site/content/3.1/components/drawer.md
@@ -30,6 +30,9 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
   <!-- Required meta tags -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
 
   <!-- Material Style CSS -->
   <link rel="stylesheet"
@@ -40,7 +43,7 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
 <body>
 
 <!-- Navbar -->
-<nav class="navbar navbar-expand-sm bg-primary navbar-dark">
+<nav class="navbar navbar-expand-sm bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
     
@@ -52,17 +55,17 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
         <span class="navbar-toggler-icon"></span>
       </button>
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
-        <i class="bi bi-star-fill me-2"></i>Brand
+        <i class="bi bi-star me-2"></i>Brand
       </a>
     </div>
   </div>
 </nav>
 
 <!-- Sidebar / Drawer -->
-<aside class="offcanvas offcanvas-start offcanvas-light" data-bs-scroll="true" tabindex="-1" id="drawer">
+<aside class="offcanvas offcanvas-start" data-bs-scroll="true" tabindex="-1" id="drawer">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
@@ -70,12 +73,12 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -102,20 +105,48 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
           </ul>
         </div>
       </li>
+      <li class="nav-item">
+        <a class="nav-link"
+           data-bs-toggle="collapse"
+           href="#menuB"
+           role="button"
+           aria-expanded="false"
+           aria-controls="menuB">
+          Menu B
+        </a>
+        <div class="collapse" id="menuB">
+          <ul class="nav flex-column">
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
     </ul>
   </div>
 </aside>
 
 <!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
-  <div class="container">
-
+  <div class="container-fluid p-2">
+  
     <!-- Your content here -->
-
+    <label class="text-center fs-1 p-5">
+      S<br>O<br>M<br>E<br><br>
+      I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
+      S<br>T<br>U<br>F<br>F
+    </label>
   </div>
 
- <!-- Footer -->
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>
@@ -141,6 +172,9 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
   <!-- Required meta tags -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
 
   <!-- Material Style CSS -->
   <link rel="stylesheet"
@@ -151,14 +185,13 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
 <body>
 
 <!-- Navbar -->
-<nav class="navbar navbar-expand-sm bg-primary navbar-dark">
+<nav class="navbar navbar-expand-sm bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
-        <i class="bi bi-star-fill me-2"></i>Brand
+        <i class="bi bi-star me-2"></i>Brand
       </a>
     </div>
-    
     <!-- Drawer toggler -->
     <button class="navbar-toggler ms-2"
             type="button"
@@ -170,10 +203,10 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
 </nav>
 
 <!-- Sidebar / Drawer -->
-<aside class="offcanvas offcanvas-end offcanvas-light" data-bs-scroll="true" tabindex="-1" id="drawer">
+<aside class="offcanvas offcanvas-end" data-bs-scroll="true" tabindex="-1" id="drawer">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
@@ -181,12 +214,12 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -213,20 +246,48 @@ We use Bootstrap's Offcanvas component for Drawers which come in two types:
           </ul>
         </div>
       </li>
+      <li class="nav-item">
+        <a class="nav-link"
+           data-bs-toggle="collapse"
+           href="#menuB"
+           role="button"
+           aria-expanded="false"
+           aria-controls="menuB">
+          Menu B
+        </a>
+        <div class="collapse" id="menuB">
+          <ul class="nav flex-column">
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
     </ul>
   </div>
 </aside>
 
 <!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
-  <div class="container">
-
+  <div class="container-fluid p-2">
+  
     <!-- Your content here -->
-
+    <label class="text-center fs-1 p-5">
+      S<br>O<br>M<br>E<br><br>
+      I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
+      S<br>T<br>U<br>F<br>F
+    </label>
   </div>
 
- <!-- Footer -->
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>
@@ -255,6 +316,9 @@ Use Breakpoints ```.offcanvas{-sm|-md|-lg|-xl|-xxl}``` to create a responsive dr
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
+
   <!-- Material Style CSS -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/@materialstyle/materialstyle@3.1.1/dist/css/materialstyle.min.css">
@@ -264,42 +328,42 @@ Use Breakpoints ```.offcanvas{-sm|-md|-lg|-xl|-xxl}``` to create a responsive dr
 <body>
 
 <!-- Navbar -->
-<nav class="navbar navbar-expand-sm bg-primary navbar-dark">
+<nav class="navbar navbar-expand-md bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
-    
+
       <!-- Drawer toggler -->
-      <button class="navbar-toggler d-sm-none me-2"
+      <button class="navbar-toggler d-md-none me-2"
               type="button"
               data-bs-toggle="offcanvas"
-              data-bs-target="#drawer">
+              data-bs-target="#drawer-responsive">
         <span class="navbar-toggler-icon"></span>
       </button>
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
-        <i class="bi bi-star-fill me-2"></i>Brand
+        <i class="bi bi-star me-2"></i>Brand
       </a>
     </div>
   </div>
 </nav>
 
 <!-- Sidebar / Drawer -->
-<aside class="offcanvas-start offcanvas-md offcanvas-light offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer">
+<aside class="offcanvas-start offcanvas-md offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer-responsive">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
-    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" data-bs-target="#drawer-responsive" aria-label="Close"></button>
   </div>
   <div class="offcanvas-body bg-primary bg-opacity-10">
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -326,20 +390,48 @@ Use Breakpoints ```.offcanvas{-sm|-md|-lg|-xl|-xxl}``` to create a responsive dr
           </ul>
         </div>
       </li>
+      <li class="nav-item">
+        <a class="nav-link"
+           data-bs-toggle="collapse"
+           href="#menuB"
+           role="button"
+           aria-expanded="false"
+           aria-controls="menuB">
+          Menu B
+        </a>
+        <div class="collapse" id="menuB">
+          <ul class="nav flex-column">
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
     </ul>
   </div>
 </aside>
 
 <!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
-  <div class="container">
+  <div class="container-fluid p-2">
 
     <!-- Your content here -->
-
+    <label class="text-center fs-1 p-5">
+      S<br>O<br>M<br>E<br><br>
+      I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
+      S<br>T<br>U<br>F<br>F
+    </label>
   </div>
 
- <!-- Footer -->
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>
@@ -366,6 +458,9 @@ Use Breakpoints ```.offcanvas{-sm|-md|-lg|-xl|-xxl}``` to create a responsive dr
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
+
   <!-- Material Style CSS -->
   <link rel="stylesheet"
         href="https://cdn.jsdelivr.net/npm/@materialstyle/materialstyle@3.1.1/dist/css/materialstyle.min.css">
@@ -375,42 +470,42 @@ Use Breakpoints ```.offcanvas{-sm|-md|-lg|-xl|-xxl}``` to create a responsive dr
 <body>
 
 <!-- Navbar -->
-<nav class="navbar navbar-expand-sm bg-primary navbar-dark">
+<nav class="navbar navbar-expand-md bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
         <i class="bi bi-star-fill me-2"></i>Brand
       </a>
     </div>
-    
+
     <!-- Drawer toggler -->
-    <button class="navbar-toggler d-sm-none ms-2"
+    <button class="navbar-toggler d-md-none ms-2"
             type="button"
             data-bs-toggle="offcanvas"
-            data-bs-target="#drawer">
+            data-bs-target="#drawer-responsive-end">
       <span class="navbar-toggler-icon"></span>
     </button>
   </div>
 </nav>
 
 <!-- Sidebar / Drawer -->
-<aside class="offcanvas-end offcanvas-md offcanvas-light offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer">
+<aside class="offcanvas-end offcanvas-md offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer-responsive-end">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
-    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" data-bs-target="#drawer-responsive-end" aria-label="Close"></button>
   </div>
   <div class="offcanvas-body bg-primary bg-opacity-10">
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -437,20 +532,48 @@ Use Breakpoints ```.offcanvas{-sm|-md|-lg|-xl|-xxl}``` to create a responsive dr
           </ul>
         </div>
       </li>
+      <li class="nav-item">
+        <a class="nav-link"
+           data-bs-toggle="collapse"
+           href="#menuB"
+           role="button"
+           aria-expanded="false"
+           aria-controls="menuB">
+          Menu B
+        </a>
+        <div class="collapse" id="menuB">
+          <ul class="nav flex-column">
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link ps-4" href="javascript:">
+                Menu Item
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
     </ul>
   </div>
 </aside>
 
 <!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
-  <div class="container">
+  <div class="container-fluid p-2">
 
     <!-- Your content here -->
-
+    <label class="text-center fs-1 p-5">
+      S<br>O<br>M<br>E<br><br>
+      I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
+      S<br>T<br>U<br>F<br>F
+    </label>
   </div>
 
- <!-- Footer -->
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>

--- a/site/content/3.1/demos/drawer-end.md
+++ b/site/content/3.1/demos/drawer-end.md
@@ -3,13 +3,15 @@ layout: demo
 title: Drawer End
 ---
 
-<nav class="navbar bg-primary navbar-dark">
+<!-- Navbar -->
+<nav class="navbar navbar-expand-sm bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
-        <i class="bi bi-star-fill me-2"></i>Brand
+        <i class="bi bi-star me-2"></i>Brand
       </a>
     </div>
+    <!-- Drawer toggler -->
     <button class="navbar-toggler ms-2"
             type="button"
             data-bs-toggle="offcanvas"
@@ -19,10 +21,11 @@ title: Drawer End
   </div>
 </nav>
 
-<aside class="offcanvas offcanvas-end offcanvas-light" data-bs-scroll="true" tabindex="-1" id="drawer-end">
+<!-- Sidebar / Drawer -->
+<aside class="offcanvas offcanvas-end" data-bs-scroll="true" tabindex="-1" id="drawer-end">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
@@ -30,12 +33,12 @@ title: Drawer End
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -86,54 +89,23 @@ title: Drawer End
           </ul>
         </div>
       </li>
-      <li class="nav-item">
-        <a class="nav-link"
-           data-bs-toggle="collapse"
-           href="#menuC"
-           role="button"
-           aria-expanded="false"
-           aria-controls="menuC">
-          Menu C
-        </a>
-        <div class="collapse" id="menuC">
-          <ul class="nav flex-column">
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
     </ul>
   </div>
 </aside>
 
+<!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
   <div class="container-fluid p-2">
-    <label class="bg-primary text-white text-center fs-1 p-5">
+    <!-- Your content here -->
+    <label class="text-center fs-1 p-5">
       S<br>O<br>M<br>E<br><br>
       I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
       S<br>T<br>U<br>F<br>F
     </label>
   </div>
 
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>

--- a/site/content/3.1/demos/drawer-responsive-end.md
+++ b/site/content/3.1/demos/drawer-responsive-end.md
@@ -3,13 +3,15 @@ layout: demo
 title: Drawer Responsive End
 ---
 
-<nav class="navbar navbar-expand-md bg-primary navbar-dark">
+<!-- Navbar -->
+<nav class="navbar navbar-expand-md bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
         <i class="bi bi-star-fill me-2"></i>Brand
       </a>
     </div>
+    <!-- Drawer toggler -->
     <button class="navbar-toggler d-md-none ms-2"
             type="button"
             data-bs-toggle="offcanvas"
@@ -19,10 +21,11 @@ title: Drawer Responsive End
   </div>
 </nav>
 
-<aside class="offcanvas-end offcanvas-md offcanvas-light offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer-responsive-end">
+<!-- Sidebar / Drawer -->
+<aside class="offcanvas-end offcanvas-md offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer-responsive-end">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" data-bs-target="#drawer-responsive-end" aria-label="Close"></button>
   </div>
@@ -30,12 +33,12 @@ title: Drawer Responsive End
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -86,54 +89,23 @@ title: Drawer Responsive End
           </ul>
         </div>
       </li>
-      <li class="nav-item">
-        <a class="nav-link"
-           data-bs-toggle="collapse"
-           href="#menuC"
-           role="button"
-           aria-expanded="false"
-           aria-controls="menuC">
-          Menu C
-        </a>
-        <div class="collapse" id="menuC">
-          <ul class="nav flex-column">
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
     </ul>
   </div>
 </aside>
 
+<!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
   <div class="container-fluid p-2">
-    <label class="bg-primary text-white text-center fs-1 p-5">
+    <!-- Your content here -->
+    <label class="text-center fs-1 p-5">
       S<br>O<br>M<br>E<br><br>
       I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
       S<br>T<br>U<br>F<br>F
     </label>
   </div>
 
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>

--- a/site/content/3.1/demos/drawer-responsive.md
+++ b/site/content/3.1/demos/drawer-responsive.md
@@ -3,9 +3,11 @@ layout: demo
 title: Drawer Responsive
 ---
 
-<nav class="navbar navbar-expand-md bg-primary navbar-dark">
+<!-- Navbar -->
+<nav class="navbar navbar-expand-md bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
+      <!-- Drawer toggler -->
       <button class="navbar-toggler d-md-none me-2"
               type="button"
               data-bs-toggle="offcanvas"
@@ -13,16 +15,17 @@ title: Drawer Responsive
         <span class="navbar-toggler-icon"></span>
       </button>
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
-        <i class="bi bi-star-fill me-2"></i>Brand
+        <i class="bi bi-star me-2"></i>Brand
       </a>
     </div>
   </div>
 </nav>
 
-<aside class="offcanvas-start offcanvas-md offcanvas-light offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer-responsive">
+<!-- Sidebar / Drawer -->
+<aside class="offcanvas-start offcanvas-md offcanvas-fixed" data-bs-scroll="true" tabindex="-1" id="drawer-responsive">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" data-bs-target="#drawer-responsive" aria-label="Close"></button>
   </div>
@@ -30,12 +33,12 @@ title: Drawer Responsive
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -86,54 +89,23 @@ title: Drawer Responsive
           </ul>
         </div>
       </li>
-      <li class="nav-item">
-        <a class="nav-link"
-           data-bs-toggle="collapse"
-           href="#menuC"
-           role="button"
-           aria-expanded="false"
-           aria-controls="menuC">
-          Menu C
-        </a>
-        <div class="collapse" id="menuC">
-          <ul class="nav flex-column">
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
     </ul>
   </div>
 </aside>
 
+<!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
   <div class="container-fluid p-2">
-    <label class="bg-primary text-white text-center fs-1 p-5">
+    <!-- Your content here -->
+    <label class="text-center fs-1 p-5">
       S<br>O<br>M<br>E<br><br>
       I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
       S<br>T<br>U<br>F<br>F
     </label>
   </div>
 
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>

--- a/site/content/3.1/demos/drawer.md
+++ b/site/content/3.1/demos/drawer.md
@@ -3,9 +3,11 @@ layout: demo
 title: Drawer
 ---
 
-<nav class="navbar bg-primary navbar-dark">
+<!-- Navbar -->
+<nav class="navbar navbar-expand-sm bg-primary">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
+      <!-- Drawer toggler -->
       <button class="navbar-toggler me-2"
               type="button"
               data-bs-toggle="offcanvas"
@@ -13,16 +15,17 @@ title: Drawer
         <span class="navbar-toggler-icon"></span>
       </button>
       <a class="navbar-brand d-flex align-items-center" href="javascript:">
-        <i class="bi bi-star-fill me-2"></i>Brand
+        <i class="bi bi-star me-2"></i>Brand
       </a>
     </div>
   </div>
 </nav>
 
-<aside class="offcanvas offcanvas-start offcanvas-light" data-bs-scroll="true" tabindex="-1" id="drawer">
+<!-- Sidebar / Drawer -->
+<aside class="offcanvas offcanvas-start" data-bs-scroll="true" tabindex="-1" id="drawer">
   <div class="offcanvas-header bg-primary">
     <a class="offcanvas-title text-white" href="javascript:">
-      <i class="bi bi-star-fill me-2"></i>Brand
+      <i class="bi bi-star me-2"></i>Brand
     </a>
     <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>
@@ -30,12 +33,12 @@ title: Drawer
     <ul class="nav flex-column">
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link A
         </a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="javascript:">
-          Link
+          Link B
         </a>
       </li>
       <li class="nav-item">
@@ -86,54 +89,23 @@ title: Drawer
           </ul>
         </div>
       </li>
-      <li class="nav-item">
-        <a class="nav-link"
-           data-bs-toggle="collapse"
-           href="#menuC"
-           role="button"
-           aria-expanded="false"
-           aria-controls="menuC">
-          Menu C
-        </a>
-        <div class="collapse" id="menuC">
-          <ul class="nav flex-column">
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link ps-4" href="javascript:">
-                Menu Item
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="javascript:">
-          Link
-        </a>
-      </li>
     </ul>
   </div>
 </aside>
 
+<!-- Offcanvas pushed content -->
 <div class="offcanvas-pushed-content">
   <div class="container-fluid p-2">
-    <label class="bg-primary text-white text-center fs-1 p-5">
+    <!-- Your content here -->
+    <label class="text-center fs-1 p-5">
       S<br>O<br>M<br>E<br><br>
       I<br>N<br>T<br>E<br>R<br>E<br>S<br>T<br>I<br>N<br>G<br><br>
       S<br>T<br>U<br>F<br>F
     </label>
   </div>
 
-  <footer class="bg-dark text-white p-3">
+  <!-- Footer -->
+  <footer class="border-top border-3 p-3">
     Footer
   </footer>
 </div>


### PR DESCRIPTION
### Description

Don't change the visibility of the offcanvas toggler based on navbar-expand-* breakpoints

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contributing guidelines](https://github.com/materialstyle/materialstyle/blob/main/.github/CONTRIBUTING.md)
- [x] My code follows the code style of the project _(using `npm run lint`)_
- [x] My change introduces changes to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

* https://deploy-preview-118--materialstyle.netlify.app/materialstyle/3.1/components/drawer/

### Related issues

<!-- Please link any related issues here. -->

Fixes #118 
