### PR TITLE
Fix checkmarks not displaying for selected options on multi-select dropdown initialization

### DIFF
--- a/js/src/select-field.js
+++ b/js/src/select-field.js
@@ -261,9 +261,10 @@ class SelectField extends BaseComponent {
       dropdownItem.append(label)
     } else {
       dropdownItem.innerHTML = text
-      if (checked) {
-        dropdownItem.setAttribute('aria-selected', 'true')
-      }
+    }
+
+    if (checked) {
+      dropdownItem.setAttribute('aria-selected', 'true')
     }
 
     return dropdownItem

--- a/scss/forms/_form-floating.scss
+++ b/scss/forms/_form-floating.scss
@@ -136,6 +136,9 @@
 
     .dropdown-item {
       min-height: 40px;
+      word-break: break-all;
+      white-space: break-spaces;
+
       > * {
         pointer-events: none;
       }
@@ -251,6 +254,7 @@
     }
 
     .checkmark {
+      flex-shrink: 0;
       width: 20px;
       height: 20px;
       visibility: hidden;


### PR DESCRIPTION
### Description

This pull request addresses an issue where selected options in the multi-select dropdown were not checkmarked on initialization.

### Motivation & Context

The user expects the previously selected options to be reflected in the UI when the dropdown is loaded.

### Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would change existing functionality)

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [contributing guidelines](https://github.com/materialstyle/materialstyle/blob/main/.github/CONTRIBUTING.md)
- [X] My code follows the code style of the project _(using `npm run lint`)_
- [ ] My change introduces changes to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

#### Live previews

<!-- Please add direct links where your modifications can be seen in the documentation -->

* https://deploy-preview-122--materialstyle.netlify.app/materialstyle/3.1/forms/select-fields/#multi-select

### Related issues

#121 
